### PR TITLE
Fix: authenticated endpoint is now without '/v2' suffix

### DIFF
--- a/src/editbtn.js
+++ b/src/editbtn.js
@@ -11,7 +11,7 @@ function setup(endpoint) {
   const baseURL = matches[1].replace(/\.cdn\.prismic\.io/, '.prismic.io');
   const target = matches[2].replace(/\.cdn\.prismic\.io/, '.prismic.io');
 
-  fetch(`${baseURL}/app/authenticated/v2`, {
+  fetch(`${baseURL}/app/authenticated`, {
     credentials: 'include',
   }).then((response) => {
     const contentType = response.headers.get('content-type');


### PR DESCRIPTION
Hello,

This PR fixes the authenticated endpoint because the `/app/authenticated/v2` endpoint leads today to a HTTP 404 error.  

Thanks!