### PR TITLE
Fix preview share functionality when loaded async

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ function startExperiment(expId) {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function domReady() {
   if (config) {
     Share.listen(config, () => {
       START_EXPERIMENT();
@@ -46,8 +46,14 @@ document.addEventListener('DOMContentLoaded', () => {
       setupEditButton();
     });
   }
-});
+}
 
+if (document.readyState === 'complete') {
+  domReady();
+else {
+  document.addEventListener('DOMContentLoaded', domReady);
+}
+  
 exports.setup = setupToolbar;
 exports.setupEditButton = setupEditButton;
 exports.startExperiment = startExperiment;


### PR DESCRIPTION
If DOMContentLoaded has already fired when the javascript loads then it will never recognize the page share hash. I need to load the prismic.js file asyncronously (because it's dynamically injected), so this was breaking the share functionality. I noticed a few people in the slack channel were having a similar issue.

This fixes that problem by executing the code immediately if DOMContentLoaded has already fired. Another solution to this would be to have a way to trigger share.listen from the window/module exports, but this seemed like the simpler API to me.