### PR TITLE
Better ready state detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,10 @@ function startExperiment(expId) {
   }
 }
 
+var isReady = false;
 function domReady() {
+  if (isReady) return;
+  isReady = true;
   if (config) {
     Share.listen(config, () => {
       START_EXPERIMENT();
@@ -48,10 +51,16 @@ function domReady() {
   }
 }
 
-if (document.readyState === 'complete') {
+if (
+  document.readyState === "complete" ||
+  (document.readyState !== "loading" && !document.documentElement.doScroll)
+) {
   domReady();
 } else {
-  document.addEventListener('DOMContentLoaded', domReady);
+  // Use the handy event callback
+	document.addEventListener("DOMContentLoaded", domReady);
+	// A fallback to window.onload, that will always work
+	window.addEventListener("load", domReady);
 }
 
 exports.setup = setupToolbar;


### PR DESCRIPTION
In #22 I fixed the shared preview functionality if you injected the script after the onload event fired. This update improves that fix so it also works in the case where DOMContentLoaded has fired, but onload hasn't happened yet. This is now essentially doing the same thing as jQuery's `$(document).ready()` so it should be more bullet-proof than the previous fix.