### PR TITLE
Reloads the page if href contains hash

### DIFF
--- a/src/share.js
+++ b/src/share.js
@@ -21,12 +21,18 @@ async function listen() {
     await close();
     Preview.close();
     window.location = Config.location.href;
+    if (window.location.hash) {
+      window.location.reload();
+    }
   }
   // Need to set cookie
   if (ref && ref !== cookie) {
     await displayLoading();
     Preview.set(ref);
     window.location = Config.location.href;
+    if (window.location.hash) {
+      window.location.reload();
+    }
   }
 }
 


### PR DESCRIPTION
This adds a `window.location.reload()` to force the page to reload if it has hash in the url.

Fixes #50