### PR TITLE
Mm/fix style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "0.0.8",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -43,7 +43,7 @@ function toggle(iframe, mode) {
     document.body.style.overflow = 'hidden';
     document.documentElement.style.overflow = 'hidden';
   } else {
-    iframe.setAttribute('style', toolbarStyle);
+    Object.assign(iframe.style, toolbarStyle);
     document.body.style = bodyStyle;
     document.documentElement.style = htmlStyle;
   }

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -25,7 +25,7 @@ function display(iframe, dimension) {
     iframe.style.right = '20px';
   }
 
-  toolbarStyle = iframe.getAttribute('style');
+  toolbarStyle = iframe.style;
   bodyStyle = document.body.style;
   htmlStyle = document.documentElement.style;
 }


### PR DESCRIPTION
#56 

toolbar style is set to "[object Object]"

isolate and recreated with
```html
<div id="foo" />
<script>
  const elem = document.getElementById("foo")
  const styl =  { width: "100px", height: "100px", backgroundColor: "red" };
  // here
  elem.setAttribute('style", styl);
<script>
```

Solved by treating style as an object,

Note: this will work on Internet explorer only if Object.assign is polyfilled.

