### PR TITLE
fix: treat dev.style as an object.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",
@@ -73,7 +73,7 @@
     "url-loader": "^1.1.2",
     "web-webpack-plugin": "4.2.1",
     "webpack": "^4.25.1",
-    "webpack-cli": "^3.1.2",
+    "webpack-cli": "^3.3.11",
     "whatwg-fetch": "^3.0.0"
   }
 }

--- a/src/common/general.js
+++ b/src/common/general.js
@@ -168,9 +168,15 @@ export const getLocation = () => {
 };
 
 // Generate a shadow DOM
+
 export const shadow = attr => {
   const div = document.createElement('div');
-  Object.entries(attr).forEach(([key, value]) => div.setAttribute(key, value));
+  Object.entries(attr).forEach(([key, value]) => {
+    if (key === 'style') {
+      return Object.assign(div.style, value);
+    }
+    return div.setAttribute(key, value);
+  });
   const shadowRoot = document.head.attachShadow && div.attachShadow({ mode: 'open' });
   document.body.appendChild(div);
   return shadowRoot || div;


### PR DESCRIPTION
#56 

fixed issue with setAttribute("style", obj) resulting in <div style="[object Object]" />

Documentation on recreating and testing this has been added to notion.

Or can be reproduce on a web-based code editor with

```
<div id="foo" />
<script>
  const elem = document.getElementById("foo")
  const styl =  { width: "100px", height: "100px", backgroundColor: "red" };
  // here
  elem.setAttribute("style", styl);
<script>
```

The following code fix the issue
```
<div id="foo" />
<script>
  const elem = document.getElementById("foo")
  const styl =  { width: "100px", height: "100px", backgroundColor: "red" };
  // here
  Object.assign(elem.style, styl);
<script>
```