### PR TITLE
Fix close preview session

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "3.0.4",
+  "version": "3.0.6",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",

--- a/src/common/cookie.js
+++ b/src/common/cookie.js
@@ -15,7 +15,7 @@ export function deleteCookie(name) {
 }
 
 // TODO remove after we force no /preview route (url prediction)
-export function demolishCookie(name) {
+export function demolishCookie(name, options) {
   const subdomains = window.location.hostname.split('.'); // ['www','gosport','com']
   const subpaths = window.location.pathname.slice(1).split('/'); // ['my','path']
 
@@ -30,7 +30,8 @@ export function demolishCookie(name) {
     .concat('/') // root path
     .concat(null); // no path specified
 
+
   DOMAINS.forEach(domain =>
-    PATHS.forEach(path => Cookies.remove(name, { domain, path }))
+    PATHS.forEach(path => Cookies.remove(name, { ...options, domain, path }))
   );
 }

--- a/src/iframe/preview.js
+++ b/src/iframe/preview.js
@@ -4,7 +4,7 @@ const SESSION_ID = getCookie('io.prismic.previewSession');
 
 // Close preview session
 function closePreviewSession () /* void */{
-  demolishCookie('io.prismic.previewSession');
+  demolishCookie('io.prismic.previewSession', { sameSite: 'None' });
 }
 
 const PreviewRef = {


### PR DESCRIPTION
Since we set the preview session cookie with a Same-Site attribute, we have to explicitly specify that attribute when we want to delete that cookie.