### PR TITLE
Mm/update html2canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",

--- a/src/toolbar/preview/screenshot.js
+++ b/src/toolbar/preview/screenshot.js
@@ -1,25 +1,11 @@
-let html2canvasPromise;
-
 const screenshot = async () => {
   document.getElementById('prismic-toolbar-v2').setAttribute('data-html2canvas-ignore', true);
-  if (!html2canvasPromise) html2canvasPromise = script('https://html2canvas.hertzen.com/dist/html2canvas.min.js');
-  await html2canvasPromise;
 
-  const canvas = await window.html2canvas(document.body, {
-    logging: false,
-    width: '100%',
-    height: window.innerHeight,
-  });
-  return new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', 0.6));
-};
-
-function script(src) {
-  return new Promise(resolve => {
-    const el = document.createElement('script');
-    el.src = src;
-    document.head.appendChild(el);
-    el.addEventListener('load', () => resolve(el));
-  });
+  const options = { logging: false, width: '100%', height: window.innerHeight };
+  
+  return import('https://html2canvas.hertzen.com/dist/html2canvas.esm.js')
+  .then(html2canvas => html2canvas(document.body, options))
+  .then(canvas => new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', 0.6)));
 }
 
 export default screenshot;

--- a/src/toolbar/preview/screenshot.js
+++ b/src/toolbar/preview/screenshot.js
@@ -2,7 +2,7 @@ let html2canvasPromise;
 
 const screenshot = async () => {
   document.getElementById('prismic-toolbar-v2').setAttribute('data-html2canvas-ignore', true);
-  if (!html2canvasPromise) html2canvasPromise = script('https://unpkg.com/html2canvas@1.0.0-alpha.12/dist/html2canvas.min.js');
+  if (!html2canvasPromise) html2canvasPromise = script('https://html2canvas.hertzen.com/dist/html2canvas.min.js');
   await html2canvasPromise;
 
   const canvas = await window.html2canvas(document.body, {

--- a/src/toolbar/preview/screenshot.js
+++ b/src/toolbar/preview/screenshot.js
@@ -1,11 +1,25 @@
+let html2canvasPromise;
+
 const screenshot = async () => {
   document.getElementById('prismic-toolbar-v2').setAttribute('data-html2canvas-ignore', true);
+  if (!html2canvasPromise) html2canvasPromise = script('https://html2canvas.hertzen.com/dist/html2canvas.min.js');
+  await html2canvasPromise;
 
-  const options = { logging: false, width: '100%', height: window.innerHeight };
-  
-  return import('https://html2canvas.hertzen.com/dist/html2canvas.esm.js')
-  .then(html2canvas => html2canvas(document.body, options))
-  .then(canvas => new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', 0.6)));
+  const canvas = await window.html2canvas(document.body, {
+    logging: false,
+    width: '100%',
+    height: window.innerHeight,
+  });
+  return new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', 0.6));
+};
+
+function script(src) {
+  return new Promise(resolve => {
+    const el = document.createElement('script');
+    el.src = src;
+    document.head.appendChild(el);
+    el.addEventListener('load', () => resolve(el));
+  });
 }
 
 export default screenshot;


### PR DESCRIPTION
Fixes: prismicio/issue-tracker-wroom/issues/259

Update the html2cavas source and version so we use the latest version by default, 
the old version was causing the issue reported and recreated here prismicio/issue-tracker-wroom/issues/259

Also there is a reverted commit for loading the script as a dynamic module (nice idea but it can be ignored for now as it causes build errors)  https://github.com/prismicio/prismic-toolbar/commit/eb731918f55e10b40985647441bd0a69e1a6e518 