### PR TITLE
mh - feat(fallback image if html2canvas fails)

### DIFF
--- a/src/toolbar/preview/screenshot.js
+++ b/src/toolbar/preview/screenshot.js
@@ -15,7 +15,7 @@ const screenshot = async () => {
     console.warn('Caught html2canvas error', e);
     // sometimes html2canvas errors.  This breaks creating a link.
     // While a preview image is nice it's not essential.
-    // If html2canvas errors we create a dummy canvas and convert that to a blog.
+    // If html2canvas errors we create a dummy canvas and convert that to a blob.
     // The preview image is a black square
     // but at least we can share the image.
     const tempCanvas = document.createElement('canvas');

--- a/src/toolbar/preview/screenshot.js
+++ b/src/toolbar/preview/screenshot.js
@@ -4,13 +4,23 @@ const screenshot = async () => {
   document.getElementById('prismic-toolbar-v2').setAttribute('data-html2canvas-ignore', true);
   if (!html2canvasPromise) html2canvasPromise = script('https://unpkg.com/html2canvas@1.0.0-alpha.12/dist/html2canvas.min.js');
   await html2canvasPromise;
-
-  const canvas = await window.html2canvas(document.body, {
-    logging: false,
-    width: '100%',
-    height: window.innerHeight,
-  });
-  return new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', 0.6));
+  try {
+    const canvas = await window.html2canvas(document.body, {
+      logging: false,
+      width: '100%',
+      height: window.innerHeight,
+    });
+    return new Promise(resolve => canvas.toBlob(resolve, 'image/jpeg', 0.6));
+  } catch (e) {
+    console.warn('Caught html2canvas error', e);
+    // sometimes html2canvas errors.  This breaks creating a link.
+    // While a preview image is nice it's not essential.
+    // If html2canvas errors we create a dummy canvas and convert that to a blog.
+    // The preview image is a black square
+    // but at least we can share the image.
+    const tempCanvas = document.createElement('canvas');
+    return new Promise(resolve => tempCanvas.toBlob(resolve, 'image/jpeg', 0.6));
+  }
 };
 
 function script(src) {


### PR DESCRIPTION
## Issue
On some pages of our website, when we try to create a prismic preview link, the html2canvas code errors.  We haven't been able to find out why the error happens.  When this errors no request gets sent off to get a preview link.

This blocks us from sharing previews from some pages on our site.  While we can debug on our side that issue (I guess some way of how we build our page) it feels like we could handle errors in that step more gracefully.  It looks like an image is required when creating the preview link when posting off to the server.

The solution we have implemented is to catch any errors,  attach a blank canvas to the page and use that to create a blank sreenshot.  This results in us getting a working preview link although without a preview image.

I haven't been able to create a sandboxed example of this so I've uploaded a video taking you through a broken example on our live site and the code in this pull request running locally that fixes it.

The toolbar is fantastic and we use the preview a lot - thanks for all your work on it.  Fixing this edge case would be super helpful for us - let me know if you have any thoughts or suggestions on either improving or tackling this issue in another way.

https://user-images.githubusercontent.com/1722189/106042355-d9e61580-60d4-11eb-9c66-e2bebbce95a3.mp4

