### PR TITLE
Fix infinite refresh loop during previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",

--- a/src/toolbar/preview/index.js
+++ b/src/toolbar/preview/index.js
@@ -44,7 +44,10 @@ export class Preview {
   async updatePreview() {
     const { reload, ref } = await this.client.updatePreview();
     this.start(ref);
-    if (reload) { reloadOrigin(); }
+    if (reload) {
+      this.cancelPreviewUpdates();
+      reloadOrigin();
+    }
   }
 
   // Start preview


### PR DESCRIPTION
This PR fixes: #66 

If a page takes more than 3 seconds to load, we get stuck in an infinite refresh loop. To prevent this issue, we make sure to call `reloadOrigin` only once.