### PR TITLE
feat(toolbar): add seo insights tab

### DIFF
--- a/src/toolbar/components/Panel/DocumentPanel.js
+++ b/src/toolbar/components/Panel/DocumentPanel.js
@@ -1,7 +1,7 @@
 import { BasePanel, prismicWhiteSvg } from '.';
 import { Icon } from '../Icon';
 import { Loader } from '../Loader';
-import { NavTabs, EditButton, DevMode } from '..';
+import { NavTabs, EditButton, SEOInsights, DevMode } from '..';
 
 export const DocumentPanel = ({ loading, documents, queries, onDocumentClick }) => {
   if (!documents || (documents && documents.length <= 0)) return null;
@@ -18,32 +18,29 @@ export const DocumentPanel = ({ loading, documents, queries, onDocumentClick }) 
 };
 
 const panelContent = (documents, queries, onDocumentClick) => {
-  // If there is no queries then, we don't display the json.
-  if (queries && queries.length > 0) {
-    return (
-      <NavTabs
-        tabsName={['Edit Button', 'Dev Mode']}
-        tabsContent={[
-          <EditButton
-            documents={documents}
-            maxTitleSize={35}
-            maxSummarySize={150}
-            onClick={onDocumentClick}
-          />,
-          <DevMode
-            maxStringSize={35}
-            queries={queries}
-          />
-        ]}
-      />
-    );
-  }
-  return (
+  const tabsName = ['Edit Button', 'SEO Insights'];
+  const tabsContent = [
     <EditButton
       documents={documents}
       maxTitleSize={35}
       maxSummarySize={150}
       onClick={onDocumentClick}
+    />,
+    <SEOInsights />
+  ];
+
+  // If there is no queries then, we don't display the json.
+  if (queries && queries.length > 0) {
+    tabsName.push('Dev Mode');
+    tabsContent.push(
+      <DevMode maxStringSize={35} queries={queries} />
+    );
+  }
+
+  return (
+    <NavTabs
+      tabsName={tabsName}
+      tabsContent={tabsContent}
     />
   );
 };

--- a/src/toolbar/components/Panel/Panel.css
+++ b/src/toolbar/components/Panel/Panel.css
@@ -7,12 +7,30 @@
     width: 400px;
     height: calc(100vh - 160px);
     position: absolute;
+    overflow-y: auto;
     bottom: 100px;
     left: 0;
-    overflow-y: auto;
     min-height: 250px;
     max-height: 650px;
     will-change: transform;
+    display: flex;
+    flex-direction: column;
+
+  & .react-tabs {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  & .toolbar-header, & .nav-tab-list {
+    flex: 0 0 auto;
+  }
+
+  & .react-tabs__tab-panel--selected {
+    flex: 1;
+    overflow-y: auto;
+  }
 
   & .top {
     padding: 30px;

--- a/src/toolbar/components/SEOInsights/SEOInsights.css
+++ b/src/toolbar/components/SEOInsights/SEOInsights.css
@@ -1,0 +1,153 @@
+/* SeoInsightsTab */
+
+.seo-insights-tab {
+  border-top: 1px solid #E0E2EE;
+  background: #FFFFFF;
+
+  /* Helpers */
+  & .ok {
+    color: hsl(150, 46%, 59%);
+  }
+
+  & .warn {
+    color: hsl(37, 100%, 52%);
+  }
+
+  & .error {
+    color: hsl(12, 100%, 52%);
+  }
+
+  /* Reset */
+  & h4, & p, & figure, & blockquote {
+    margin: 0;
+  }
+
+  /* Title */
+  & article h4 {
+    font-size: 13px;
+    color: #8091A5;
+    letter-spacing: 0;
+    line-height: 35px;
+    background: #F5F6F9;
+    padding: 0 25px;
+    border-bottom: 1px solid #E0E2EE;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  & article ~ article h4 {
+    border-top: 1px solid #E0E2EE;
+  }
+
+  & article h4 a {
+    font-weight: 400;
+    display: flex;
+    gap: 5px;
+    border-radius: 10px;
+    padding: 5px;
+    margin: -5px;
+    line-height: 1.5;
+  }
+
+  & article h4 a .Icon {
+    width: 20px;
+    height: 20px;
+    vertical-align: sub;
+  }
+
+  & article h4 a:hover {
+    background: rgba(128, 145, 165, 0.15);
+  }
+
+  /* Figure */
+  & article figure {
+    padding: 10px 25px;
+  }
+
+  & article blockquote {
+    padding: 5px 0;
+    font-size: 14px;
+    font-style: italic;
+    color: #293258;
+  }
+
+  & article figcaption {
+    border-top: 1px solid #E0E2EE;
+    padding: 5px 0;
+  }
+
+  /* Hint */
+  & article .hint {
+    cursor: help;
+  }
+
+  /* Main Hints */
+  & article blockquote.hint {
+    display: flex;
+    gap: 5px;
+    font-style: normal;
+    font-size: 13px;
+  }
+
+  & article blockquote.hint .Icon {
+    width: 20px;
+    height: 20px;
+  }
+
+  /* Sub Hints */
+  & article figcaption .hint .Icon {
+    width: 18px;
+    height: 18px;
+    vertical-align: sub;
+  }
+
+  /* Meta Image */
+  & article.metaImage .metaImageWrapper {
+    margin: 5px 0;
+    padding-bottom: 52.356%;
+    position: relative;
+  }
+
+  & article.metaImage .metaImageWrapper:after {
+    content: "See Full Size";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(81, 98, 186, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #FFFFFF;
+    font-size: 16px;
+    font-weight: 700;
+    opacity: 0;
+    will-change: opacity;
+    transition: opacity 0.3s ease-in-out;
+  }
+
+  & article.metaImage .metaImageWrapper:hover:after {
+    opacity: 1;
+  }
+  
+  & article.metaImage .metaImageWrapper img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  /* Meta Debuggers */
+  & article.metaDebuggers p {
+    padding: 10px 25px;
+  }
+
+  & article.metaDebuggers a {
+    display: inline;
+    text-decoration: underline;
+  }
+}

--- a/src/toolbar/components/SEOInsights/SEOInsights.js
+++ b/src/toolbar/components/SEOInsights/SEOInsights.js
@@ -1,0 +1,307 @@
+import './SEOInsights.css';
+import { Component } from 'react';
+import { Icon } from '../Icon';
+import { infoSvg, okSvg, warnSvg, errorSvg } from '.';
+
+/* ----- BEGINNING OF CLASS ----- */
+export class SEOInsights extends Component {
+  insights = null;
+
+  constructor (props) {
+    super(props);
+    this.refreshInsights();
+  }
+
+  refreshInsights() {
+    const result = {
+      meta: {
+        title: null,
+        description: null,
+        image: null,
+        openGraph: {
+          title: null,
+          description: null,
+          image: null
+        },
+        twitter: {
+          title: null,
+          description: null,
+          image: null
+        }
+      }
+    };
+
+    const getMetaPropertySafely = (selector, property) => {
+      try {
+        const tag = document.querySelector(`head ${selector}`);
+        return tag ? tag[property] : null;
+      } catch (e) {
+        return null;
+      }
+    };
+
+    result.meta.title = getMetaPropertySafely('title', 'innerText');
+    result.meta.description = getMetaPropertySafely('meta[name="description"]', 'content');
+
+    result.meta.openGraph.title = getMetaPropertySafely('meta[property="og:title"]', 'content');
+    result.meta.openGraph.description = getMetaPropertySafely('meta[property="og:description"]', 'content');
+    // We give open graph priority to define global meta image
+    result.meta.image = result.meta.openGraph.image = getMetaPropertySafely('meta[property="og:image"]', 'content');
+
+    result.meta.twitter.title = getMetaPropertySafely('meta[name="twitter:title"]', 'content');
+    result.meta.twitter.description = getMetaPropertySafely('meta[name="twitter:description"]', 'content');
+    result.meta.twitter.image = getMetaPropertySafely('meta[name="twitter:image"]', 'content');
+
+    this.insights = result;
+  }
+
+  /* ----- RENDER FUNCTION ----- */
+  render() {
+    if (!this.insights) {
+      return (<div className="seo-insights-tab">
+        <article>
+          <h4>Loading SEO Insights...</h4>
+        </article>
+      </div>);
+    }
+
+    return (
+      <div className="seo-insights-tab">
+        { DisplayMetaTitle(this.insights) }
+        { DisplayMetaDescription(this.insights) }
+        <DisplayMetaImage insights={this.insights} />
+        { DisplayMetaDebuggers() }
+      </div>
+    );
+  }
+}
+
+const Protocol = {
+  openGraph: 'Open Graph',
+  twitter: 'Twitter'
+};
+
+const Meta = {
+  title: 'page title',
+  description: 'page description',
+  image: 'page social image',
+};
+
+const ucFirst = str => str.charAt(0).toUpperCase() + str.slice(1);
+
+const DisplayEmpty = (meta, value) => {
+  let className = 'hint error';
+  let message = `${ucFirst(meta)} not found`;
+  let icon = errorSvg;
+
+  if (value === '') {
+    className = 'hint warn';
+    message = `${ucFirst(meta)} is empty`;
+    icon = warnSvg;
+  }
+
+  return (
+    <figure>
+      <blockquote className={className} title={message}>
+        <Icon src={icon} /> {message}
+      </blockquote>
+    </figure>
+  );
+};
+
+const DisplayHint = (protocol, meta, value) => {
+  let className = 'hint error';
+  let title = `${protocol} meta tag not found for ${meta}`;
+  let icon = errorSvg;
+
+  if (value === '') {
+    className = 'hint warn';
+    title = `${protocol} meta tag is empty for ${meta}`;
+    icon = warnSvg;
+  }
+
+  if (value) {
+    className = 'hint ok';
+    title = `${protocol} meta tag is correctly set for ${meta}`;
+    icon = okSvg;
+  }
+
+  return (
+    <span
+      className={className}
+      title={title}
+    >
+      {protocol} <Icon src={icon} />
+    </span>
+  );
+};
+
+const DisplayMetaTitle = insights => (
+  <article className="metaTitle">
+    <h4>
+      Page Title
+      <a
+        target="_blank"
+        rel="noopener"
+        href="https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets#page-titles"
+        title="Learn more about page title"
+      >More info <Icon src={infoSvg} /></a>
+    </h4>
+    {
+      insights.meta.title ? (
+        <figure>
+          <blockquote>{ insights.meta.title }</blockquote>
+          <figcaption>
+            <span
+              className="hint"
+              title="Google typically displays the first 50-60 characters of the page title"
+            >
+              Title Length: { insights.meta.title.length }
+            </span> - {
+              DisplayHint(Protocol.openGraph, Meta.title, insights.meta.openGraph.title)
+            } - {
+              DisplayHint(Protocol.twitter, Meta.title, insights.meta.twitter.title)
+            }
+          </figcaption>
+        </figure>
+      ) : DisplayEmpty(Meta.title, insights.meta.title)
+    }
+  </article>
+);
+
+const DisplayMetaDescription = insights => (
+  <article className="metaDescription">
+    <h4>
+      Page Description
+      <a
+        target="_blank"
+        rel="noopener"
+        href="https://developers.google.com/search/docs/advanced/appearance/good-titles-snippets#meta-descriptions"
+        title="Learn more about page description"
+      >More info <Icon src={infoSvg} /></a>
+    </h4>
+    {
+      insights.meta.description ? (
+        <figure>
+          <blockquote>{ insights.meta.description }</blockquote>
+          <figcaption>
+            <span
+              className="hint"
+              title="Google typically displays the first 155-160 characters of the page description"
+            >
+              Description Length: { insights.meta.description.length }
+            </span> - {
+              DisplayHint(
+                Protocol.openGraph,
+                Meta.description,
+                insights.meta.openGraph.description
+              )
+            } - {
+              DisplayHint(
+                Protocol.twitter,
+                Meta.description,
+                insights.meta.twitter.description
+              )
+            }
+          </figcaption>
+        </figure>
+      ) : DisplayEmpty(Meta.description, insights.meta.description)
+    }
+  </article>
+);
+
+class DisplayMetaImage extends Component {
+  insights = null;
+
+  state = { ref: null, width: null, height: null, ratio: null };
+
+  constructor (props) {
+    super(props);
+    this.insights = props.insights;
+  }
+
+  onImageChange = node => {
+    if (node) {
+      node.onload = () => {
+        this.setState({
+          ref: node,
+          width: node?.naturalWidth,
+          height: node?.naturalHeight,
+          ratio: `1:${(Math.ceil(node?.naturalWidth / node?.naturalHeight * 100) / 100).toFixed(2)}`
+        });
+      };
+      node.src = this.insights.meta.image;
+    }
+  }
+
+  render() {
+    const { insights } = this;
+    const { width, height, ratio } = this.state;
+
+    return (
+      <article className="metaImage">
+        <h4>
+          Page Social Image
+          <a
+            target="_blank"
+            rel="noopener"
+            href="https://yoast.com/advanced-technical-seo-social-image-ogimage-tags"
+            title="Learn more about page social image"
+          >More info <Icon src={infoSvg} /></a>
+        </h4>
+        {
+          insights.meta.description ? (
+            <figure>
+              <a className="metaImageWrapper" target="prismicToolbarMetaImage" rel="noopener" href={insights.meta.image} >
+                <img src={insights.meta.image} ref={this.onImageChange} />
+              </a>
+              <figcaption>
+                <span
+                  className="hint"
+                  title="Social media typically displays this image using a 1:1.92 aspect ratio"
+                >
+                  Image Ratio: {ratio} ({width}px / {height}px)
+                </span><br />{
+                  DisplayHint(Protocol.openGraph, Meta.image, insights.meta.openGraph.image)
+                } - {
+                  DisplayHint(Protocol.twitter, Meta.image, insights.meta.twitter.image)
+                }
+              </figcaption>
+            </figure>
+          ) : DisplayEmpty(Meta.image, insights.meta.image)
+        }
+      </article>
+    );
+  }
+}
+
+const DisplayMetaDebuggers = () => (
+  <article className="metaDebuggers">
+    <h4>
+      Official Debuggers
+    </h4>
+    <p>
+      <a
+        target="_blank"
+        rel="noopener"
+        href="https://developers.facebook.com/tools/debug"
+        title="Facebook OpenGraph debugger"
+      >Facebook</a> - <a
+        target="_blank"
+        rel="noopener"
+        href="https://cards-dev.twitter.com/validator"
+        title="Twitter debugger"
+      >Twitter</a> - <a
+        target="_blank"
+        rel="noopener"
+        href="https://www.linkedin.com/post-inspector/inspect"
+        title="LinkedIn debugger"
+      >LinkedIn</a> - <a
+        target="_blank"
+        rel="noopener"
+        href="https://search.google.com/structured-data/testing-tool/u/0"
+        title="Google structured data debugger"
+      >Structured Data</a>
+    </p>
+  </article>
+);

--- a/src/toolbar/components/SEOInsights/error.svg
+++ b/src/toolbar/components/SEOInsights/error.svg
@@ -1,0 +1,1 @@
+<svg fill="none" stroke="#ff3b0a" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>

--- a/src/toolbar/components/SEOInsights/index.js
+++ b/src/toolbar/components/SEOInsights/index.js
@@ -1,0 +1,5 @@
+export { SEOInsights } from './SEOInsights';
+export { default as infoSvg } from './info.svg';
+export { default as okSvg } from './ok.svg';
+export { default as warnSvg } from './warn.svg';
+export { default as errorSvg } from './error.svg';

--- a/src/toolbar/components/SEOInsights/info.svg
+++ b/src/toolbar/components/SEOInsights/info.svg
@@ -1,0 +1,1 @@
+<svg fill="none" stroke="#8091A5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>

--- a/src/toolbar/components/SEOInsights/ok.svg
+++ b/src/toolbar/components/SEOInsights/ok.svg
@@ -1,0 +1,1 @@
+<svg fill="none" stroke="#66c796" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>

--- a/src/toolbar/components/SEOInsights/warn.svg
+++ b/src/toolbar/components/SEOInsights/warn.svg
@@ -1,0 +1,1 @@
+<svg fill="none" stroke="#ffa10a" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg>

--- a/src/toolbar/components/index.js
+++ b/src/toolbar/components/index.js
@@ -17,3 +17,4 @@ export { NavTabs } from './NavTabs';
 export { DevMode } from './DevMode';
 export { JsonView } from './JsonView';
 export { EditButton } from './EditButton';
+export { SEOInsights } from './SEOInsights';


### PR DESCRIPTION
# Status

🧪 &nbsp;This is an experiment on the toolbar. Design and code are likely to change if we agree on moving forward with this idea.

# Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Overview

This is a quick experiment I made on the toolbar to adds an additional "SEO Insights" tab to it:

![toolbar](https://user-images.githubusercontent.com/25330882/125477482-b7869f9b-0281-4f23-8da2-7dd209b6d9e9.gif)

Here what this new tab is doing:
- Displays current page meta title, description, and image;
- Gives basic hints on each of them;
- Checks for their counterpart on Open Graph & Twitter protocol;
- Displays errors if tags are not found, warning if they are empty;
- Provides additional resources from Google and social media official debuggers.

# Try it yourself

Just replace your toolbar script with this one and replace `YOUR_REPO` with yours:

```
https://prismic-toolbar-seo.netlify.app/prismic-toolbar/4.0.5/prismic.js?repo=YOUR_REPO&new=true
```

Should be working!