### PR TITLE
fix: improve setup port warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.0.4",
+  "version": "4.0.7",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",

--- a/src/toolbar-service/index.js
+++ b/src/toolbar-service/index.js
@@ -45,18 +45,47 @@ const Client = {
 };
 
 const Iframe = {
+  // If initialization has been delayed
+  initializationDelayed: false,
+  // Warning messages to be shown upon delayed initialization
+  initializationDelayedTimeouts: [],
+  // If iframe has been initialized
+  initialized: false,
+
   async setup() /* void */ {
+    // Reset initialization state (iframe should only be setup once though)
+    Iframe.initializationDelayed = false;
+    Iframe.initializationDelayedTimeouts = [];
+    Iframe.initialized = false;
+
     window.addEventListener('message', msg => Iframe.initialisationMessageHandler(msg));
   },
 
   initialisationMessageHandler(/* MessageEvent */message) /* void */ {
     if (message.data === ToolbarServiceProtocol.SetupPort) {
+      // Checking for `initialized` has a quicker effect than removing the listener because we can check for it after
+      Iframe.initialized = true;
+
       window.removeEventListener('message', msg => Iframe.initialisationMessageHandler(msg));
       const portToMainWindow = message.ports[0];
       setupIframe(portToMainWindow);
       portToMainWindow.postMessage(ToolbarServiceProtocol.Ready);
-    } else {
-      throw Error(`Unexpected message received by the iframe: ${message}.\n Expected ${ToolbarServiceProtocol.SetupPort}`);
+
+      // Clear all ongoing timeouts
+      Iframe.initializationDelayedTimeouts.forEach(timeout => clearTimeout(timeout));
+
+      // If iframe has been delayed, let the user know that the toolbar managed to get ready
+      if (Iframe.initializationDelayed) {
+      // eslint-disable-next-line no-console
+        console.info('%cPrismic toolbar initialized successfully! This message only appears when unexpected messages were received by the iframe during Prismic toolbar setup.\n', 'color: #52b256;');
+      }
+    } else if (!Iframe.initialized) {
+      // Setting a timeout allows to buffer first few messages the iframe might receive when waiting for its own init message
+      Iframe.initializationDelayedTimeouts.push(setTimeout(() => {
+        // If timeout is reached, then iframe had been delayed and may not be initialized
+        Iframe.initializationDelayed = true;
+        console.warn(`Unexpected message received by the iframe during Prismic toolbar setup.\n\nExpected: ${ToolbarServiceProtocol.SetupPort}\nReceived: ${typeof message.data === 'string' ? message.data : JSON.stringify(message.data)}\n\nThis can happen due to an extension tampering with iframes (Dashlane, MetaMask, etc.)\n\nAn explicit message following this one will let you know if the toolbar was successfully initialized.`);
+      }, 500));
     }
   }
 };

--- a/src/toolbar-service/index.js
+++ b/src/toolbar-service/index.js
@@ -63,7 +63,8 @@ const Iframe = {
 
   initialisationMessageHandler(/* MessageEvent */message) /* void */ {
     if (message.data === ToolbarServiceProtocol.SetupPort) {
-      // Checking for `initialized` has a quicker effect than removing the listener because we can check for it after
+      // Checking for `initialized` has a quicker effect than removing the listener
+      // because we can check for it after
       Iframe.initialized = true;
 
       window.removeEventListener('message', msg => Iframe.initialisationMessageHandler(msg));
@@ -80,7 +81,8 @@ const Iframe = {
         console.info('%cPrismic toolbar initialized successfully! This message only appears when unexpected messages were received by the iframe during Prismic toolbar setup.\n', 'color: #52b256;');
       }
     } else if (!Iframe.initialized) {
-      // Setting a timeout allows to buffer first few messages the iframe might receive when waiting for its own init message
+      // Setting a timeout allows to buffer first few messages the iframe might receive
+      // when waiting for its own init message
       Iframe.initializationDelayedTimeouts.push(setTimeout(() => {
         // If timeout is reached, then iframe had been delayed and may not be initialized
         Iframe.initializationDelayed = true;


### PR DESCRIPTION
# Status

✅ &nbsp;This PR is ready, awaiting review & QA.

# Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Overview

Some extensions can send messages to iframes, this can cause the toolbar to report false-positive errors during its init process.

This Pull Request adds a buffer during the toolbar initialization process, displaying improved warning only if the toolbar did not init after a given timeout (500ms).

Fixes #60