### PR TITLE
feat: allow declaring document used manually using meta tags

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,58 +1,65 @@
-const path = require('path');
+const path = require("path");
 
 module.exports = {
-  parser: 'babel-eslint',
-  extends: ['standard', 'standard-preact', 'airbnb-base'],
+  parser: "babel-eslint",
+  extends: ["standard", "standard-preact", "airbnb-base"],
   env: {
     browser: true,
     jest: true,
   },
   rules: {
-    'no-unused-expressions': 0,
-    'prefer-template': 0,
-    'no-confusing-arrow': 0,
-    'import/no-cycle': 0, // maybe revert this one (config-experiment, panel-children)
-    'no-await-in-loop': 0,
-    'promise/param-names': 0,
-    'class-methods-use-this': 0,
-    'func-names': 0,
+    "no-unused-expressions": 0,
+    "prefer-template": 0,
+    "no-confusing-arrow": 0,
+    "import/no-cycle": 0, // maybe revert this one (config-experiment, panel-children)
+    "no-await-in-loop": 0,
+    "promise/param-names": 0,
+    "class-methods-use-this": 0,
+    "func-names": 0,
     "global-require": 0,
-    'no-new': 0,
-    'no-multi-assign': 0,
-    'space-before-function-paren': 0,
-    'function-paren-newline': 0,
-    'no-param-reassign': 0,
-    'no-return-assign': [2, 'except-parens'],
-    'no-use-before-define': 0,
-    'consistent-return': 0,
-    'no-prototype-builtins': 0,
-    'arrow-parens': [2, 'as-needed'],
-    'no-console': [2, { allow: ['warn', 'error'] }],
-    'prefer-rest-params': 0,
-    'nonblock-statement-body-position': 0,
-    'no-underscore-dangle': 0,
-    'react/react-in-jsx-scope': 0,
-    'comma-dangle': [
-      'error',
+    "no-new": 0,
+    "no-multi-assign": 0,
+    "space-before-function-paren": 0,
+    "function-paren-newline": 0,
+    "no-param-reassign": 0,
+    "no-return-assign": [2, "except-parens"],
+    "no-use-before-define": 0,
+    "consistent-return": 0,
+    "no-prototype-builtins": 0,
+    "arrow-parens": [2, "as-needed"],
+    "no-console": [2, { allow: ["warn", "error"] }],
+    "prefer-rest-params": 0,
+    "nonblock-statement-body-position": 0,
+    "no-underscore-dangle": 0,
+    "react/react-in-jsx-scope": 0,
+    "comma-dangle": [
+      "error",
       {
-        arrays: 'only-multiline',
-        objects: 'only-multiline',
-        imports: 'only-multiline',
-        exports: 'only-multiline',
-        functions: 'ignore',
+        arrays: "only-multiline",
+        objects: "only-multiline",
+        imports: "only-multiline",
+        exports: "only-multiline",
+        functions: "ignore",
       },
     ],
-    'import/prefer-default-export': 0,
-    'import/no-extraneous-dependencies': 0,
-    'object-curly-newline': 0,
-    'implicit-arrow-linebreak': 0,
+    "import/prefer-default-export": 0,
+    "import/no-extraneous-dependencies": 0,
+    "object-curly-newline": 0,
+    "implicit-arrow-linebreak": 0,
     curly: 0,
+    "no-unused-vars": [
+      "error",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+      },
+    ],
   },
-  "settings": {
+  settings: {
     "import/resolver": {
       webpack: {
-        config: 'webpack.config.js'
-      }
-    }
-  }
+        config: "webpack.config.js",
+      },
+    },
+  },
 };

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# asserts everything is text
+* text eol=lf
+
+# treats lock files as binaries to prevent merge headache
+package-lock.json -diff
+yarn.lock -diff
+
+# treats assets as binaries
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@babel/preset-env": "^7.11.0",
         "@babel/preset-react": "^7.10.4",
         "@babel/preset-stage-2": "^7.8.3",
+        "@prismicio/client": "^6.2.0",
         "babel-eslint": "^10.0.1",
         "babel-loader": "^8.0.4",
         "clean-webpack-plugin": "3.0.0",
@@ -3323,6 +3324,55 @@
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@prismicio/client": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.2.0.tgz",
+      "integrity": "sha512-IUeFjWL7ebI6812JLbGavBXqooX7J5h9GYMC1Jbzc8hva2MvYv/XRvj0EbShXYXjNacNYly9Z5jkMqdIPGlvJg==",
+      "dev": true,
+      "dependencies": {
+        "@prismicio/helpers": "^2.1.1",
+        "@prismicio/types": "^0.1.23"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/@prismicio/helpers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.1.1.tgz",
+      "integrity": "sha512-jP17J0ot3zOEMqL3yJteAQW6zwR2ttWwowpVJ02Q6sBk1K9DFfQbQ9ySA4tkBQS0ki3ttWFnrERDzCZ/xCCvGQ==",
+      "dev": true,
+      "dependencies": {
+        "@prismicio/richtext": "^2.0.1",
+        "@prismicio/types": "^0.1.23",
+        "escape-html": "^1.0.3",
+        "imgix-url-builder": "^0.0.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      }
+    },
+    "node_modules/@prismicio/richtext": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.0.1.tgz",
+      "integrity": "sha512-sM+eusvE4PsKnwefDRd0ai3Ny59XJ54dn6xfwq0Fyqj0LAcuyB2gRjSufbIqYOZ1r4JKMQArDKrypNEcrbBFkA==",
+      "dev": true,
+      "dependencies": {
+        "@prismicio/types": "^0.1.22"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      }
+    },
+    "node_modules/@prismicio/types": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.24.tgz",
+      "integrity": "sha512-jugSx4sgzux0dCWwlEZSjTo98rryxNlHLkdlBbMHpAFJjjor8Jqt+cN7PSCxPTkUbynHEFIwuNCbJhoLU+gEGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.7.0"
       }
     },
     "node_modules/@types/anymatch": {
@@ -9564,6 +9614,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/imgix-url-builder": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/imgix-url-builder/-/imgix-url-builder-0.0.2.tgz",
+      "integrity": "sha512-PHT9aXvD+I6x5UAdvsAKNALvxHI1AWGGpxLUQDQAXzUt54ScFHxxODJ/4/XWDM55cqvRCvT3MMxbOWjgWhLe9Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.7.0"
       }
     },
     "node_modules/immutability-helper": {
@@ -20699,6 +20758,43 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==",
       "dev": true
     },
+    "@prismicio/client": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@prismicio/client/-/client-6.2.0.tgz",
+      "integrity": "sha512-IUeFjWL7ebI6812JLbGavBXqooX7J5h9GYMC1Jbzc8hva2MvYv/XRvj0EbShXYXjNacNYly9Z5jkMqdIPGlvJg==",
+      "dev": true,
+      "requires": {
+        "@prismicio/helpers": "^2.1.1",
+        "@prismicio/types": "^0.1.23"
+      }
+    },
+    "@prismicio/helpers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@prismicio/helpers/-/helpers-2.1.1.tgz",
+      "integrity": "sha512-jP17J0ot3zOEMqL3yJteAQW6zwR2ttWwowpVJ02Q6sBk1K9DFfQbQ9ySA4tkBQS0ki3ttWFnrERDzCZ/xCCvGQ==",
+      "dev": true,
+      "requires": {
+        "@prismicio/richtext": "^2.0.1",
+        "@prismicio/types": "^0.1.23",
+        "escape-html": "^1.0.3",
+        "imgix-url-builder": "^0.0.2"
+      }
+    },
+    "@prismicio/richtext": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@prismicio/richtext/-/richtext-2.0.1.tgz",
+      "integrity": "sha512-sM+eusvE4PsKnwefDRd0ai3Ny59XJ54dn6xfwq0Fyqj0LAcuyB2gRjSufbIqYOZ1r4JKMQArDKrypNEcrbBFkA==",
+      "dev": true,
+      "requires": {
+        "@prismicio/types": "^0.1.22"
+      }
+    },
+    "@prismicio/types": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@prismicio/types/-/types-0.1.24.tgz",
+      "integrity": "sha512-jugSx4sgzux0dCWwlEZSjTo98rryxNlHLkdlBbMHpAFJjjor8Jqt+cN7PSCxPTkUbynHEFIwuNCbJhoLU+gEGA==",
+      "dev": true
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -24855,24 +24951,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
+          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -24883,12 +24983,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -24899,36 +25001,42 @@
         },
         "chownr": {
           "version": "1.1.3",
+          "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "3.2.6",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -24938,24 +25046,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -24965,12 +25077,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -24987,6 +25101,7 @@
         },
         "glob": {
           "version": "7.1.6",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25001,12 +25116,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
+          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25016,6 +25133,7 @@
         },
         "ignore-walk": {
           "version": "3.0.3",
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25025,6 +25143,7 @@
         },
         "inflight": {
           "version": "1.0.6",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25035,18 +25154,21 @@
         },
         "inherits": {
           "version": "2.0.4",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25056,12 +25178,14 @@
         },
         "isarray": {
           "version": "1.0.0",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25071,12 +25195,14 @@
         },
         "minimist": {
           "version": "0.0.8",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.9.0",
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25087,6 +25213,7 @@
         },
         "minizlib": {
           "version": "1.3.3",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25096,6 +25223,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25105,12 +25233,14 @@
         },
         "ms": {
           "version": "2.1.2",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.4.0",
+          "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25122,6 +25252,7 @@
         },
         "node-pre-gyp": {
           "version": "0.14.0",
+          "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25140,6 +25271,7 @@
         },
         "nopt": {
           "version": "4.0.1",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25150,6 +25282,7 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
+          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25159,12 +25292,14 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.7",
+          "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25175,6 +25310,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25187,18 +25323,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25208,18 +25347,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25230,18 +25372,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
+          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25254,6 +25399,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -25262,6 +25408,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25277,6 +25424,7 @@
         },
         "rimraf": {
           "version": "2.7.1",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25286,42 +25434,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25331,6 +25486,7 @@
         },
         "string-width": {
           "version": "1.0.2",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25342,6 +25498,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25351,12 +25508,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.13",
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25372,12 +25531,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
+          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -25387,12 +25548,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.1.1",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -25836,6 +25999,12 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "imgix-url-builder": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/imgix-url-builder/-/imgix-url-builder-0.0.2.tgz",
+      "integrity": "sha512-PHT9aXvD+I6x5UAdvsAKNALvxHI1AWGGpxLUQDQAXzUt54ScFHxxODJ/4/XWDM55cqvRCvT3MMxbOWjgWhLe9Q==",
       "dev": true
     },
     "immutability-helper": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.0.7",
+  "version": "4.1.0",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",
@@ -26,6 +26,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-stage-2": "^7.8.3",
+    "@prismicio/client": "^6.2.0",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.4",
     "clean-webpack-plugin": "3.0.0",

--- a/src/toolbar/metaPrediction.js
+++ b/src/toolbar/metaPrediction.js
@@ -1,0 +1,140 @@
+import { createClient, ForbiddenError } from '@prismicio/client';
+
+const PRISMIC_MAIN_DOCUMENT = 'prismic-main-document';
+const PRISMIC_DOCUMENTS = 'prismic-documents';
+
+// Get main and sub documents IDs from meta
+export const getDocumentIDsFromMeta = (silent = false) => {
+  // Get `prismic-main-document` meta tags
+  const $main = document.querySelectorAll(
+    `meta[name="${PRISMIC_MAIN_DOCUMENT}"]`
+  );
+  // Get `prismic-documents` meta tags
+  const $subs = document.querySelectorAll(`meta[name="${PRISMIC_DOCUMENTS}"]`);
+
+  // If page uses meta tags
+  if ($main.length || $subs.length) {
+    if (!silent) {
+      // Warn about wrong `prismic-main-document` usage
+      if ($main.length === 0) {
+        console.warn(
+          '[prismic-toolbar] No main document found, for better results, please declare your main document using the `prismic-main-document` meta tag.'
+        );
+      } else if ($main.length > 1) {
+        console.warn(
+          '[prismic-toolbar] Multiple `prismic-main-document` meta tags found, only the first one will be used.'
+        );
+      }
+    }
+
+    // Get main document
+    const main = $main[0] ? $main[0].content : null;
+
+    // Get sub documents
+    const subs = [...$subs]
+      .map(sub => sub.content.split(',').map(id => id.trim()))
+      .flat()
+      .filter((id, index, arr) =>
+        id && arr.indexOf(id) === index && id !== main
+      ) // Filters duplicates and main
+      .slice(0, main ? 19 : 20); // Limit to a total of 20
+
+    // Return if we have at least one document
+    if (main || subs.length) {
+      return { main, subs };
+    }
+  }
+
+  return null;
+};
+
+export const watchHead = callback => {
+  const $head = document.querySelector('head');
+  if ($head) {
+    const observer = new MutationObserver(async mutationsList => {
+      for (let i = 0; i < mutationsList.length; i++) {
+        const nodes = [
+          mutationsList[i].target,
+          ...mutationsList[i].addedNodes,
+          ...mutationsList[i].removedNodes
+        ];
+
+        // If some nodes are Prismic meta tags...
+        if (nodes.some(node => [PRISMIC_MAIN_DOCUMENT, PRISMIC_DOCUMENTS].includes(node.name))) {
+          // ...run callback (update precdiction)
+          await callback();
+
+          break;
+        }
+      }
+    });
+
+    observer.observe($head, { attributes: true, childList: true, attributeFilter: ['name', 'content'], subtree: true });
+  }
+};
+
+export const forceDocumentTracking = async docIDs => {
+  // Create client
+  const client = createClient(`${this.apiEndPoint}/api/v2`);
+
+  // Query main and sub documents
+  try {
+    await client.getByIDs([docIDs.main, ...docIDs.subs].filter(Boolean));
+  } catch (error) {
+    if (error instanceof ForbiddenError) {
+      console.warn("[prismic-toolbar] Meta tags-based prediction doesn't work yet with private repositories.");
+    } else {
+      // Fail silently but log error for debugging ease
+      console.error(error);
+    }
+  }
+};
+
+export const tamperDocumentsAndQueries = (docIDs, documentsSorted, queriesResults) => {
+  // Sort main document first when available
+  if (docIDs.main) {
+    documentsSorted = documentsSorted.sort((a, _b) => a.id === docIDs.main ? -1 : 1);
+  }
+
+  // All ids queried
+  const ids = [docIDs.main, ...docIDs.subs].filter(Boolean);
+  // Find the query made above in query results
+  const allIDsQueryIndex = queriesResults.findIndex(query =>
+    query.length === ids.length
+    && query.every(doc => ids.includes(doc.id))
+  );
+
+  // If we found the query
+  if (allIDsQueryIndex !== -1) {
+    // Group results by type
+    queriesResults = Object.values(
+      queriesResults
+        // queriesResults is a nested array of documents
+        .flat()
+        // Filter unique documents
+        .filter((doc1, index, arr) => arr.findIndex(doc2 => doc2.id === doc1.id) === index)
+        // Group by type
+        .reduce((acc, doc) => {
+          (acc[doc.type] ||= []).push(doc);
+
+          return acc;
+        }, {})
+    );
+
+    if (docIDs.main) {
+      queriesResults = queriesResults
+        // Sort main document type group at top
+        .sort((a, _b) => a.some(doc => doc.id === docIDs.main) ? -1 : 1)
+        // Sort main document at top of first group
+        .map((docs, index) => {
+          if (index === 0) {
+            return docs.sort((a, _b) => a.id === docIDs.main ? -1 : 1);
+          }
+
+          return docs;
+        });
+    }
+  }
+
+  return [documentsSorted, queriesResults];
+};

--- a/src/toolbar/prediction.js
+++ b/src/toolbar/prediction.js
@@ -1,8 +1,5 @@
 import { Hooks, getLocation, wait } from '@common';
-import { createClient, ForbiddenError } from '@prismicio/client';
-
-const PRISMIC_MAIN_DOCUMENT = 'prismic-main-document';
-const PRISMIC_DOCUMENTS = 'prismic-documents';
+import { getDocumentIDsFromMeta, watchHead, forceDocumentTracking, tamperDocumentsAndQueries } from './metaPrediction';
 
 export class Prediction {
   constructor(client, previewCookie) {
@@ -29,79 +26,15 @@ export class Prediction {
     this.hooks.on('historyChange', () => this.start());
 
     // Update prediction on meta change
-    const $head = document.querySelector('head');
-    if ($head) {
-      const observer = new MutationObserver(async mutationsList => {
-        for (let i = 0; i < mutationsList.length; i++) {
-          const nodes = [
-            mutationsList[i].target,
-            ...mutationsList[i].addedNodes,
-            ...mutationsList[i].removedNodes
-          ];
-
-          // If some nodes are Prismic meta tags...
-          if (nodes.some(node => [PRISMIC_MAIN_DOCUMENT, PRISMIC_DOCUMENTS].includes(node.name))) {
-            // ...update prediction
-            this.dispatchLoading();
-            await this.predict(this.cookie.getTracker());
-            this.cookie.refreshTracker();
-
-            break;
-          }
-        }
-      });
-
-      observer.observe($head, { attributes: true, childList: true, attributeFilter: ['name', 'content'], subtree: true });
-    }
+    watchHead(async () => {
+      this.dispatchLoading();
+      await this.predict(this.cookie.getTracker());
+      this.cookie.refreshTracker();
+    });
 
     // Start prediction
     await this.start(currentTracker);
   };
-
-  // Get main and sub documents IDs from meta
-  getDocumentIDsFromMeta = (silent = false) => {
-    // Get `prismic-main-document` meta tags
-    const $main = document.querySelectorAll(
-      `meta[name="${PRISMIC_MAIN_DOCUMENT}"]`
-    );
-    // Get `prismic-documents` meta tags
-    const $subs = document.querySelectorAll(`meta[name="${PRISMIC_DOCUMENTS}"]`);
-
-    // If page uses meta tags
-    if ($main.length || $subs.length) {
-      if (!silent) {
-        // Warn about wrong `prismic-main-document` usage
-        if ($main.length === 0) {
-          console.warn(
-            '[prismic-toolbar] No main document found, for better results, please declare your main document using the `prismic-main-document` meta tag.'
-          );
-        } else if ($main.length > 1) {
-          console.warn(
-            '[prismic-toolbar] Multiple `prismic-main-document` meta tags found, only the first one will be used.'
-          );
-        }
-      }
-
-      // Get main document
-      const main = $main[0] ? $main[0].content : null;
-
-      // Get sub documents
-      const subs = [...$subs]
-        .map(sub => sub.content.split(',').map(id => id.trim()))
-        .flat()
-        .filter((id, index, arr) =>
-          id && arr.indexOf(id) === index && id !== main
-        ) // Filters duplicates and main
-        .slice(0, main ? 19 : 20); // Limit to a total of 20
-
-      // Return if we have at least one document
-      if (main || subs.length) {
-        return { main, subs };
-      }
-    }
-
-    return null;
-  }
 
   // Start predictions for this URL
   start = async maybeTracker => {
@@ -109,7 +42,7 @@ export class Prediction {
     this.dispatchLoading();
     // Wait less when using meta tags-based prediction since we'll have to query anyway after,
     // this allow for the edit button to be snappier
-    await wait(this.getDocumentIDsFromMeta(true) ? 1 : 2);
+    await wait(getDocumentIDsFromMeta(true) ? 1 : 2);
 
     // load prediction
     const tracker = maybeTracker || this.cookie.getTracker();
@@ -123,23 +56,8 @@ export class Prediction {
       let queriesResults;
 
       // Force querying documents from meta tags-based prediction
-      const docIDs = this.getDocumentIDsFromMeta();
-      if (docIDs) {
-        // Create client
-        const client = createClient(`${this.apiEndPoint}/api/v2`);
-
-        // Query main and sub documents
-        try {
-          await client.getByIDs([docIDs.main, ...docIDs.subs].filter(Boolean));
-        } catch (error) {
-          if (error instanceof ForbiddenError) {
-            console.warn("[prismic-toolbar] Meta tags-based prediction doesn't work yet with private repositories.");
-          } else {
-            // Fail silently but log error for debugging ease
-            console.error(error);
-          }
-        }
-      }
+      const docIDs = getDocumentIDsFromMeta();
+      if (docIDs) await forceDocumentTracking(docIDs);
 
       // Run prediction
       documentsSorted = await this.client.getPredictionDocs({
@@ -154,50 +72,9 @@ export class Prediction {
 
       // Tamper with automatic prediction if user used meta tags-based prediction
       if (docIDs) {
-        // Sort main document first when available
-        if (docIDs.main) {
-          documentsSorted = documentsSorted.sort((a, _b) => a.id === docIDs.main ? -1 : 1);
-        }
-
-        // All ids queried
-        const ids = [docIDs.main, ...docIDs.subs].filter(Boolean);
-        // Find the query made above in query results
-        const allIDsQueryIndex = queriesResults.findIndex(query =>
-          query.length === ids.length
-          && query.every(doc => ids.includes(doc.id))
+        [documentsSorted, queriesResults] = tamperDocumentsAndQueries(
+          docIDs, documentsSorted, queriesResults
         );
-
-        // If we found the query
-        if (allIDsQueryIndex !== -1) {
-          // Group results by type
-          queriesResults = Object.values(
-            queriesResults
-              // queriesResults is a nested array of documents
-              .flat()
-              // Filter unique documents
-              .filter((doc1, index, arr) => arr.findIndex(doc2 => doc2.id === doc1.id) === index)
-              // Group by type
-              .reduce((acc, doc) => {
-                (acc[doc.type] ||= []).push(doc);
-
-                return acc;
-              }, {})
-          );
-
-          if (docIDs.main) {
-            queriesResults = queriesResults
-              // Sort main document type group at top
-              .sort((a, _b) => a.some(doc => doc.id === docIDs.main) ? -1 : 1)
-              // Sort main document at top of first group
-              .map((docs, index) => {
-                if (index === 0) {
-                  return docs.sort((a, _b) => a.id === docIDs.main ? -1 : 1);
-                }
-
-                return docs;
-              });
-          }
-        }
       }
 
       this.dispatch(documentsSorted, queriesResults);

--- a/src/toolbar/prediction.js
+++ b/src/toolbar/prediction.js
@@ -115,9 +115,9 @@ export class Prediction {
         tracker,
         location: getLocation(),
       });
-      queriesResults = await this.client.getDevModeQueriesResults({
+      queriesResults = (await this.client.getDevModeQueriesResults({
         tracker,
-      });
+      })).filter(Boolean);
 
       // Tamper with automatic prediction if user used meta tags-based prediction
       if (docIDs) {

--- a/src/toolbar/prediction.js
+++ b/src/toolbar/prediction.js
@@ -1,4 +1,5 @@
 import { Hooks, getLocation, wait } from '@common';
+import { createClient, ForbiddenError } from '@prismicio/client';
 
 export class Prediction {
   constructor(client, previewCookie) {
@@ -15,65 +16,174 @@ export class Prediction {
   buildApiEndpoint = () /* String */ => {
     const protocol = this.client.hostname.includes('.test') ? 'http' : 'https';
     return protocol + '://' + this.client.hostname;
-  }
+  };
 
   // Set event listener
   setup = async () => {
     const currentTracker = this.cookie.getTracker();
     this.hooks.on('historyChange', () => this.start());
     await this.start(currentTracker);
+  };
+
+  // Get main and sub documents IDs from meta
+  getDocumentIDsFromMeta = (silent = false) => {
+    // Get `prismic-main-document` meta tags
+    const $main = document.querySelectorAll(
+      'meta[name="prismic-main-document"]'
+    );
+    // Get `prismic-documents` meta tags
+    const $subs = document.querySelectorAll('meta[name="prismic-documents"]');
+
+    // If page uses meta tags
+    if ($main.length || $subs.length) {
+      if (!silent) {
+        // Warn about wrong `prismic-main-document` usage
+        if ($main.length === 0) {
+          console.warn(
+            '[prismic-toolbar] No main document found, for better results, please declare your main document using the `prismic-main-document` meta tag.'
+          );
+        } else if ($main.length > 1) {
+          console.warn(
+            '[prismic-toolbar] Multiple `prismic-main-document` meta tags found, only the first one will be used.'
+          );
+        }
+      }
+
+      // Get main document
+      const main = $main[0] ? $main[0].content : null;
+
+      // Get sub documents
+      const subs = [...$subs]
+        .map(sub => sub.content.split(',').map(id => id.trim()))
+        .flat()
+        .filter((id, index, arr) =>
+          id && arr.indexOf(id) === index && id !== main
+        ) // Filters duplicates and main
+        .slice(0, main ? 19 : 20); // Limit to a total of 20
+
+      // Return if we have at least one document
+      if (main || subs.length) {
+        return { main, subs };
+      }
+    }
+
+    return null;
   }
 
   // Start predictions for this URL
   start = async maybeTracker => {
     // wait for all requests to be played first (client side)
     this.dispatchLoading();
-    await wait(2);
+    // Wait less when using meta tags-based prediction since we'll have to query anyway after,
+    // this allow for the edit button to be snappier
+    await wait(this.getDocumentIDsFromMeta(true) ? 0.5 : 2);
+
     // load prediction
     const tracker = maybeTracker || this.cookie.getTracker();
     await this.predict(tracker);
     this.cookie.refreshTracker();
-  }
+  };
 
-  // Fetch predicted documents
-  predict = tracker => (
+  predict = tracker =>
     new Promise(async resolve => {
-      const documentsSorted = await this.client.getPredictionDocs({
+      let documentsSorted;
+      let queriesResults;
+
+      // Force querying documents from meta tags-based prediction
+      const docIDs = this.getDocumentIDsFromMeta();
+      if (docIDs) {
+        // Create client
+        const client = createClient(`${this.apiEndPoint}/api/v2`);
+
+        // Query main and sub documents
+        try {
+          await client.getByIDs([docIDs.main, ...docIDs.subs].filter(Boolean));
+        } catch (error) {
+          if (error instanceof ForbiddenError) {
+            console.warn("[prismic-toolbar] Meta tags-based prediction doesn't work yet with private repositories.");
+          } else {
+            // Fail silently but log error for debugging ease
+            console.error(error);
+          }
+        }
+      }
+
+      // Run prediction
+      documentsSorted = await this.client.getPredictionDocs({
         ref: this.cookie.getRefForDomain(),
         url: window.location.pathname,
         tracker,
-        location: getLocation()
+        location: getLocation(),
       });
-      const queriesResults = await this.client.getDevModeQueriesResults({ tracker });
+      queriesResults = await this.client.getDevModeQueriesResults({
+        tracker,
+      });
+
+      // Tamper with automatic prediction if user used meta tags-based prediction
+      if (docIDs) {
+        // Sort main document first when available
+        if (docIDs.main) {
+          documentsSorted = documentsSorted.sort((a, _b) => a.id === docIDs.main ? -1 : 1);
+        }
+
+        // All ids queried
+        const ids = [docIDs.main, ...docIDs.subs].filter(Boolean);
+
+        // Find the query made above in query results
+        const allIDsQueryIndex = queriesResults.findIndex(query =>
+          query.length === ids.length
+          && query.every(doc => ids.includes(doc.id))
+        );
+
+        // If we found the query
+        if (allIDsQueryIndex !== -1) {
+          if (queriesResults.length === 1) {
+            // If only the above query was made, improve the query results by grouping documents,
+            // sorting the main one at top
+            queriesResults = Object.values(queriesResults[allIDsQueryIndex].reduce((acc, doc) => {
+              (acc[doc.type] ||= []).push(doc);
+
+              return acc;
+            }, {})).sort((a, _b) => a.some(doc => doc.id === docIDs.main) ? -1 : 1);
+          } else {
+            // Else filter queries from the above query
+            queriesResults = [
+              ...queriesResults.filter((_query, index) => index !== allIDsQueryIndex)
+            ];
+          }
+        }
+      }
+
       this.dispatch(documentsSorted, queriesResults);
       resolve();
-    })
-  )
+    });
 
   retryPrediction = () => {
     const nextRetryMs = this.retry * 1000; // 1s / 2s / 3s
     setTimeout(this.predict, nextRetryMs);
-  }
+  };
 
   // Dispatch documents to hooks
   dispatch = (documents, queries) => {
-    Object.values(this.documentHooks).forEach(hook => hook(documents, queries)); // Run the hooks
-  }
+    Object.values(this.documentHooks).forEach(hook =>
+      hook(documents, queries)
+    ); // Run the hooks
+  };
 
   dispatchLoading = () => {
     Object.values(this.documentLoadingHooks).forEach(hook => hook());
-  }
+  };
 
   onDocumentsLoading = func => {
-    const c = this.count += 1; // Create the hook key
+    const c = (this.count += 1); // Create the hook key
     this.documentLoadingHooks[c] = func; // Create the hook
     return () => delete this.documentLoadingHooks[c]; // Alternative to removeEventListener
-  }
+  };
 
   // Documents hook
   onDocuments = func => {
-    const c = this.count += 1; // Create the hook key
+    const c = (this.count += 1); // Create the hook key
     this.documentHooks[c] = func; // Create the hook
     return () => delete this.documentHooks[c]; // Alternative to removeEventListener
-  }
+  };
 }


### PR DESCRIPTION
# Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Overview

Following #94, this PR implements strategy 1 described there. Used documents can be explicitly declared using meta tags to help predictions.

## Usage

**Declaring the main document**

```html
<meta name="prismic-main-document" content="U0V72AEAAE4netWJ" />
```

> None, or multiple instance of this meta tag will result in a warning being emitted.

**Declaring other documents**

```html
<meta name="prismic-documents" content="U0V72AEAAE4netWJ,YfmNTRIAAC8AiccC" />
```

> Multiple instance of this meta tags are allowed

## Considerations & Limitations

Instead of bypassing the prediction process, I preferred to just make a query and let the prediction process track it. This allows for the prediction API to still resolve prediction-related data that aren't resolvable otherwise (document publication status, abstract, etc.)

This addition only works with public repositories for now.

# Try it yourself

Just replace your toolbar script with this one and replace `YOUR_REPO` with yours:

```
https://prismic-toolbar-meta-predictions.netlify.app/prismic-toolbar/4.0.7/prismic.js?repo=YOUR_REPO&new=true
```

Should be working!