### PR TITLE
fix: continue checking for preview updates if the page is not reloaded on a `previewUpdate` event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prismic-toolbar",
-      "version": "4.0.8",
+      "version": "4.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "js-cookie": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",

--- a/src/iframe/index.html
+++ b/src/iframe/index.html
@@ -1,7 +1,4 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>Prismic Toolbar iFrame</title>
-<head>
-    <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet">
-</head>
 <script src="iframe?_inline"></script>

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -88,27 +88,27 @@ async function setup (rawInput) {
   const { initialRef, upToDate, isActive } = await preview.setup();
   const { convertedLegacy } = previewCookieHelper.init(initialRef);
 
-  if (isActive) {
-    if (convertedLegacy || !upToDate) {
-      reloadOrigin();
-      return;
-    }
+  if (convertedLegacy || !upToDate) {
+    reloadOrigin();
+    return;
+  }
 
-    if (previewState.auth) {
-      // eslint-disable-next-line no-undef
-      await script(`${CDN_HOST}/prismic-toolbar/${version}/toolbar.js`);
-      new window.prismic.Toolbar({
-        displayPreview: isActive,
-        auth: previewState.auth,
-        preview,
-        prediction,
-        analytics
-      });
+  if (isActive || previewState.auth) {
+    // eslint-disable-next-line no-undef
+    await script(`${CDN_HOST}/prismic-toolbar/${version}/toolbar.js`);
+    new window.prismic.Toolbar({
+      displayPreview: isActive,
+      auth: previewState.auth,
+      preview,
+      prediction,
+      analytics
+    });
 
-      // Track initial setup of toolbar
-      if (analytics) analytics.trackToolbarSetup();
-    }
-  } else {
+    // Track initial setup of toolbar
+    if (analytics) analytics.trackToolbarSetup();
+  }
+
+  if (!isActive) {
     if (previewCookieHelper.getRefForDomain())
       previewCookieHelper.deletePreviewForDomain();
 

--- a/src/toolbar/preview/index.js
+++ b/src/toolbar/preview/index.js
@@ -55,10 +55,9 @@ export class Preview {
     const { reload, ref } = await this.client.updatePreview();
     this.start(ref);
     if (reload) {
-      this.cancelPreviewUpdates();
-
       // Dispatch the update event and hard reload if not cancelled by handlers
       if (dispatchToolbarEvent(toolbarEvents.previewUpdate, { ref })) {
+        this.cancelPreviewUpdates();
         reloadOrigin();
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a bug where the toolbar would stop checking for preview updates after the first occurance _if the `previewUpdate` event prevents page reloading_.

This change is necessary to support client-side data refreshing where a full page reload is unnecessary.

Without this PR, only the first preview update is loaded; the toolbar stops checking for updates at that point.
