### PR TITLE
fix: load toolbar when authenticated or in a preview session

### DIFF
--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -88,27 +88,27 @@ async function setup (rawInput) {
   const { initialRef, upToDate, isActive } = await preview.setup();
   const { convertedLegacy } = previewCookieHelper.init(initialRef);
 
-  if (isActive) {
-    if (convertedLegacy || !upToDate) {
-      reloadOrigin();
-      return;
-    }
+  if (convertedLegacy || !upToDate) {
+    reloadOrigin();
+    return;
+  }
 
-    if (previewState.auth) {
-      // eslint-disable-next-line no-undef
-      await script(`${CDN_HOST}/prismic-toolbar/${version}/toolbar.js`);
-      new window.prismic.Toolbar({
-        displayPreview: isActive,
-        auth: previewState.auth,
-        preview,
-        prediction,
-        analytics
-      });
+  if (isActive || previewState.auth) {
+    // eslint-disable-next-line no-undef
+    await script(`${CDN_HOST}/prismic-toolbar/${version}/toolbar.js`);
+    new window.prismic.Toolbar({
+      displayPreview: isActive,
+      auth: previewState.auth,
+      preview,
+      prediction,
+      analytics
+    });
 
-      // Track initial setup of toolbar
-      if (analytics) analytics.trackToolbarSetup();
-    }
-  } else {
+    // Track initial setup of toolbar
+    if (analytics) analytics.trackToolbarSetup();
+  }
+
+  if (!isActive) {
     if (previewCookieHelper.getRefForDomain())
       previewCookieHelper.deletePreviewForDomain();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR fixes a regression introduced in #97.

The Prismic toolbar should be loaded in the following situations:

- **Logged in to Prismic, not in a preview session.**
   In this situation, the toolbar loads the Edit button. The Edit button will only appear if Prismic is aware of a document that matches the current URL.

- **Not logged in to Prismic, in a preview session.**
   In this situation, the toolbar loads the preview UI in a special unauthenticated mode. Someone may reach this state by using a preview share link or by logging out during an active preview session.

\#97 inadvertently removed both behaviors. They are restored in this PR.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
