### PR TITLE
feat(preview): support editor-embedded website preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.1.2",
+  "version": "4.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prismic-toolbar",
-      "version": "4.1.2",
+      "version": "4.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "js-cookie": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.1.2",
+  "version": "4.1.4",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",

--- a/src/common/cookie.js
+++ b/src/common/cookie.js
@@ -6,7 +6,11 @@ export function getCookie(name) {
 
 export function setCookie(name, value, expires = Infinity /* days */) {
   const path = '/';
-  return Cookies.set(name, value, { path, expires, sameSite: 'lax' });
+  return Cookies.set(name, value, {
+    path,
+    expires,
+    ...getSameSiteAttributes(),
+  });
 }
 
 export function deleteCookie(name) {
@@ -34,4 +38,12 @@ export function demolishCookie(name, options) {
   DOMAINS.forEach(domain =>
     PATHS.forEach(path => Cookies.remove(name, { ...options, domain, path }))
   );
+}
+
+function getSameSiteAttributes() {
+  if (window.self !== window.top && window.location.protocol === 'https:') {
+    return { sameSite: 'none', secure: true };
+  }
+
+  return { sameSite: 'lax' };
 }

--- a/src/common/cookie.js
+++ b/src/common/cookie.js
@@ -36,7 +36,9 @@ export function demolishCookie(name, options) {
 
 
   DOMAINS.forEach(domain =>
-    PATHS.forEach(path => Cookies.remove(name, { ...options, domain, path }))
+    PATHS.forEach(path =>
+      Cookies.remove(name, { ...getSameSiteAttributes(), ...options, domain, path })
+    )
   );
 }
 

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -5,7 +5,7 @@ const readyMessageType = 'prismic:embedded-preview:ready';
 
 const allowedParentOrigins = [
   /^https:\/\/([^/]+\.)?prismic\.io$/,
-  /^https:\/\/([^/]+\.)?wroom\.com$/,
+  /^https:\/\/([^/]+\.)?wroom\.io$/,
   'https://marketing-tools-wroom.com',
   'http://localhost:5173',
 ];
@@ -47,8 +47,6 @@ function isSetRefMessage(data) {
     && typeof data === 'object'
     && data.type === setRefMessageType
     && typeof data.token === 'string'
-    && typeof data.documentId === 'string'
-    && typeof data.versionId === 'string'
     && typeof data.refreshId === 'string'
   );
 }

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -26,26 +26,18 @@ export function isEmbeddedPreview() {
 }
 
 export function setupEmbeddedPreview({ preview }) {
-  if (!isEmbeddedPreview()) return;
-
   window.addEventListener('message', event => {
     if (!isAllowedParentOrigin(event.origin)) return;
     if (!isSetRefMessage(event.data)) return;
-    // An empty token would end the session and hard-reload the iframe
-    if (!event.data.token) return;
 
     preview.updateFromRef(event.data.token).catch(error => {
       console.error('Failed to update embedded preview ref.', error);
     });
   });
 
-  announceReady();
-
-  function announceReady() {
-    // Safe to broadcast to '*': no data in this message, and both sides
-    // validate origins on the ref messages that follow.
-    window.parent.postMessage({ type: readyMessageType }, '*');
-  }
+  // Safe to broadcast to '*': no data in this message, and both sides
+  // validate origins on the ref messages that follow.
+  window.parent.postMessage({ type: readyMessageType }, '*');
 }
 
 function isSetRefMessage(data) {
@@ -54,6 +46,7 @@ function isSetRefMessage(data) {
     && typeof data === 'object'
     && data.type === setRefMessageType
     && typeof data.token === 'string'
+    && data.token.length > 0
   );
 }
 

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -10,6 +10,7 @@ const allowedParentOrigins = [
   /^https:\/\/([^/]+\.)?marketing-tools-wroom\.com$/,
   /^https:\/\/([^/]+\.)?platform-wroom\.com$/,
   /^https:\/\/([^/]+\.)?devops-wroom\.com$/,
+  /^https:\/\/[a-z0-9-]+-prismic\.vercel\.app$/,
 ];
 
 const devParentOrigins = [

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -6,11 +6,13 @@ const readyMessageType = 'prismic:embedded-preview:ready';
 const allowedParentOrigins = [
   /^https:\/\/([^/]+\.)?prismic\.io$/,
   /^https:\/\/([^/]+\.)?wroom\.io$/,
-  /^https:\/\/([^/]+\.)?vercel\.app$/,
   /^https:\/\/([^/]+\.)?dev-tools-wroom\.com$/,
   /^https:\/\/([^/]+\.)?marketing-tools-wroom\.com$/,
   /^https:\/\/([^/]+\.)?platform-wroom\.com$/,
   /^https:\/\/([^/]+\.)?devops-wroom\.com$/,
+];
+
+const devParentOrigins = [
   /^http:\/\/localhost:\d+$/,
   /^http:\/\/127\.0\.0\.1:\d+$/,
 ];
@@ -28,6 +30,8 @@ export function setupEmbeddedPreview({ preview }) {
   window.addEventListener('message', event => {
     if (!isAllowedParentOrigin(event.origin)) return;
     if (!isSetRefMessage(event.data)) return;
+    // An empty token would end the session and hard-reload the iframe
+    if (!event.data.token) return;
 
     preview.updateFromRef(event.data.token).catch(error => {
       console.error('Failed to update embedded preview ref.', error);
@@ -37,6 +41,8 @@ export function setupEmbeddedPreview({ preview }) {
   announceReady();
 
   function announceReady() {
+    // Safe to broadcast to '*': no data in this message, and both sides
+    // validate origins on the ref messages that follow.
     window.parent.postMessage({ type: readyMessageType }, '*');
   }
 }
@@ -53,8 +59,14 @@ function isSetRefMessage(data) {
 function isAllowedParentOrigin(origin) {
   if (!origin) return false;
 
-  return allowedParentOrigins.some(allowedOrigin => {
-    if (typeof allowedOrigin === 'string') return allowedOrigin === origin;
-    return allowedOrigin.test(origin);
-  });
+  const isLocalToolbar = isLocalOrigin(window.location.origin);
+  const allowed = isLocalToolbar
+    ? [...allowedParentOrigins, ...devParentOrigins]
+    : allowedParentOrigins;
+
+  return allowed.some(allowedOrigin => allowedOrigin.test(origin));
+}
+
+function isLocalOrigin(origin) {
+  return devParentOrigins.some(devOrigin => devOrigin.test(origin));
 }

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -53,14 +53,10 @@ function isSetRefMessage(data) {
 function isAllowedParentOrigin(origin) {
   if (!origin) return false;
 
-  const isLocalToolbar = isLocalOrigin(window.location.origin);
-  const allowed = isLocalToolbar
-    ? [...allowedParentOrigins, ...devParentOrigins]
-    : allowedParentOrigins;
+  const allowed = [
+    ...allowedParentOrigins,
+    ...(isEmbeddedPreview() ? devParentOrigins : []),
+  ];
 
   return allowed.some(allowedOrigin => allowedOrigin.test(origin));
-}
-
-function isLocalOrigin(origin) {
-  return devParentOrigins.some(devOrigin => devOrigin.test(origin));
 }

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -1,0 +1,120 @@
+const markerParam = 'prismic_embed_preview';
+const debugParam = 'prismic_embed_preview_debug';
+
+const setRefMessageType = 'prismic:embedded-preview:set-ref';
+const readyMessageType = 'prismic:embedded-preview:ready';
+const timingMessageType = 'prismic:embedded-preview:timing';
+const softRefreshRenderedEventType = 'prismic:embedded-preview:soft-refresh-rendered';
+
+const allowedParentOrigins = [
+  /^https:\/\/([^/]+\.)?prismic\.io$/,
+  /^https:\/\/([^/]+\.)?wroom\.com$/,
+  'https://marketing-tools-wroom.com',
+  'http://localhost:5173',
+];
+
+export function isEmbeddedPreview() {
+  return (
+    window.self !== window.top
+    && new URLSearchParams(window.location.search).get(markerParam) === 'true'
+  );
+}
+
+export function setupEmbeddedPreview({ preview }) {
+  if (!isEmbeddedPreview()) return;
+
+  let parentOrigin;
+  let lastRefreshId;
+  let currentTiming;
+
+  window.addEventListener('message', event => {
+    if (!isAllowedParentOrigin(event.origin)) return;
+    if (!isSetRefMessage(event.data)) return;
+
+    parentOrigin = event.origin;
+
+    const timing = Object.assign({}, event.data.timing || {}, {
+      iframeReceivedAt: Date.now(),
+    });
+
+    if (lastRefreshId === event.data.refreshId) return;
+    lastRefreshId = event.data.refreshId;
+
+    const nextTiming = Object.assign({}, timing, {
+      iframeSoftRefreshRequestedAt: Date.now(),
+    });
+    currentTiming = nextTiming;
+
+    preview.updateFromRef(event.data.token).catch(error => {
+      console.error('Failed to update embedded preview ref.', error);
+    });
+  });
+  window.addEventListener(softRefreshRenderedEventType, event => {
+    const renderedRefreshId = event.detail && typeof event.detail.refreshId === 'string'
+      ? event.detail.refreshId
+      : lastRefreshId;
+
+    if (!renderedRefreshId || renderedRefreshId !== lastRefreshId || !currentTiming) {
+      return;
+    }
+
+    currentTiming = Object.assign({}, currentTiming, {
+      iframeSoftRefreshRenderedAt: Date.now(),
+    });
+
+    reportTiming({
+      parentOrigin,
+      stage: 'iframe-soft-refresh-rendered',
+      timing: currentTiming,
+    });
+  });
+
+  announceReady();
+
+  function announceReady() {
+    window.parent.postMessage({ type: readyMessageType }, '*');
+  }
+}
+
+function isSetRefMessage(data) {
+  return (
+    data
+    && typeof data === 'object'
+    && data.type === setRefMessageType
+    && typeof data.token === 'string'
+    && typeof data.documentId === 'string'
+    && typeof data.versionId === 'string'
+    && typeof data.refreshId === 'string'
+    && (
+      data.timing === undefined
+      || (typeof data.timing === 'object' && data.timing !== null)
+    )
+  );
+}
+
+function isAllowedParentOrigin(origin) {
+  if (!origin) return false;
+
+  return allowedParentOrigins.some(allowedOrigin => {
+    if (typeof allowedOrigin === 'string') return allowedOrigin === origin;
+    return allowedOrigin.test(origin);
+  });
+}
+
+function reportTiming({ parentOrigin, stage, timing }) {
+  if (!shouldReportTiming(parentOrigin)) return;
+
+  window.parent.postMessage({
+    type: timingMessageType,
+    stage,
+    timing,
+  }, parentOrigin);
+}
+
+function shouldReportTiming(parentOrigin) {
+  return (
+    parentOrigin
+    && isAllowedParentOrigin(parentOrigin)
+    && new URLSearchParams(window.location.search).get(debugParam) === 'true'
+  );
+}

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -1,10 +1,7 @@
 const markerParam = 'prismic_embed_preview';
-const debugParam = 'prismic_embed_preview_debug';
 
 const setRefMessageType = 'prismic:embedded-preview:set-ref';
 const readyMessageType = 'prismic:embedded-preview:ready';
-const timingMessageType = 'prismic:embedded-preview:timing';
-const softRefreshRenderedEventType = 'prismic:embedded-preview:soft-refresh-rendered';
 
 const allowedParentOrigins = [
   /^https:\/\/([^/]+\.)?prismic\.io$/,
@@ -23,49 +20,17 @@ export function isEmbeddedPreview() {
 export function setupEmbeddedPreview({ preview }) {
   if (!isEmbeddedPreview()) return;
 
-  let parentOrigin;
   let lastRefreshId;
-  let currentTiming;
 
   window.addEventListener('message', event => {
     if (!isAllowedParentOrigin(event.origin)) return;
     if (!isSetRefMessage(event.data)) return;
 
-    parentOrigin = event.origin;
-
-    const timing = Object.assign({}, event.data.timing || {}, {
-      iframeReceivedAt: Date.now(),
-    });
-
     if (lastRefreshId === event.data.refreshId) return;
     lastRefreshId = event.data.refreshId;
 
-    const nextTiming = Object.assign({}, timing, {
-      iframeSoftRefreshRequestedAt: Date.now(),
-    });
-    currentTiming = nextTiming;
-
     preview.updateFromRef(event.data.token).catch(error => {
       console.error('Failed to update embedded preview ref.', error);
-    });
-  });
-  window.addEventListener(softRefreshRenderedEventType, event => {
-    const renderedRefreshId = event.detail && typeof event.detail.refreshId === 'string'
-      ? event.detail.refreshId
-      : lastRefreshId;
-
-    if (!renderedRefreshId || renderedRefreshId !== lastRefreshId || !currentTiming) {
-      return;
-    }
-
-    currentTiming = Object.assign({}, currentTiming, {
-      iframeSoftRefreshRenderedAt: Date.now(),
-    });
-
-    reportTiming({
-      parentOrigin,
-      stage: 'iframe-soft-refresh-rendered',
-      timing: currentTiming,
     });
   });
 
@@ -85,10 +50,6 @@ function isSetRefMessage(data) {
     && typeof data.documentId === 'string'
     && typeof data.versionId === 'string'
     && typeof data.refreshId === 'string'
-    && (
-      data.timing === undefined
-      || (typeof data.timing === 'object' && data.timing !== null)
-    )
   );
 }
 
@@ -99,22 +60,4 @@ function isAllowedParentOrigin(origin) {
     if (typeof allowedOrigin === 'string') return allowedOrigin === origin;
     return allowedOrigin.test(origin);
   });
-}
-
-function reportTiming({ parentOrigin, stage, timing }) {
-  if (!shouldReportTiming(parentOrigin)) return;
-
-  window.parent.postMessage({
-    type: timingMessageType,
-    stage,
-    timing,
-  }, parentOrigin);
-}
-
-function shouldReportTiming(parentOrigin) {
-  return (
-    parentOrigin
-    && isAllowedParentOrigin(parentOrigin)
-    && new URLSearchParams(window.location.search).get(debugParam) === 'true'
-  );
 }

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -6,8 +6,13 @@ const readyMessageType = 'prismic:embedded-preview:ready';
 const allowedParentOrigins = [
   /^https:\/\/([^/]+\.)?prismic\.io$/,
   /^https:\/\/([^/]+\.)?wroom\.io$/,
-  'https://marketing-tools-wroom.com',
-  'http://localhost:5173',
+  /^https:\/\/([^/]+\.)?vercel\.app$/,
+  /^https:\/\/([^/]+\.)?dev-tools-wroom\.com$/,
+  /^https:\/\/([^/]+\.)?marketing-tools-wroom\.com$/,
+  /^https:\/\/([^/]+\.)?platform-wroom\.com$/,
+  /^https:\/\/([^/]+\.)?devops-wroom\.com$/,
+  /^http:\/\/localhost:\d+$/,
+  /^http:\/\/127\.0\.0\.1:\d+$/,
 ];
 
 export function isEmbeddedPreview() {
@@ -20,14 +25,9 @@ export function isEmbeddedPreview() {
 export function setupEmbeddedPreview({ preview }) {
   if (!isEmbeddedPreview()) return;
 
-  let lastRefreshId;
-
   window.addEventListener('message', event => {
     if (!isAllowedParentOrigin(event.origin)) return;
     if (!isSetRefMessage(event.data)) return;
-
-    if (lastRefreshId === event.data.refreshId) return;
-    lastRefreshId = event.data.refreshId;
 
     preview.updateFromRef(event.data.token).catch(error => {
       console.error('Failed to update embedded preview ref.', error);
@@ -47,7 +47,6 @@ function isSetRefMessage(data) {
     && typeof data === 'object'
     && data.type === setRefMessageType
     && typeof data.token === 'string'
-    && typeof data.refreshId === 'string'
   );
 }
 

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -79,7 +79,8 @@ if (!IS_EMBEDDED || isEmbeddedPreview()) {
     setupDomain = domain;
 
     if (isEmbeddedPreview()) {
-      const previewCookieHelper = new PreviewCookie(false, domain);
+      // Refs arrive via set-ref messages; the stub client only guards Preview.end()
+      const previewCookieHelper = new PreviewCookie(/* auth */ false, domain);
       const preview = new Preview({
         closePreviewSession: async () => {},
       }, previewCookieHelper, {});

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -100,7 +100,6 @@ if (!IS_EMBEDDED || isEmbeddedPreview()) {
     // Start concurrently preview (always) and prediction (if authenticated)
     const { initialRef, upToDate, isActive } = await preview.setup();
     const { convertedLegacy } = previewCookieHelper.init(initialRef);
-    setupEmbeddedPreview({ preview });
 
     if (convertedLegacy || !upToDate) {
       reloadOrigin();

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -9,9 +9,12 @@ import { PreviewCookie } from './preview/cookie';
 import { isEmbeddedPreview, setupEmbeddedPreview } from './embedded-preview';
 
 const version = process.env.npm_package_version;
-const IS_EMBEDDED = window.self !== window.top;
+const isTopLevel = window.self === window.top;
 
-if (!IS_EMBEDDED || isEmbeddedPreview()) {
+// Run at the top level, or inside the editor's embedded preview iframe
+const shouldRunToolbar = isTopLevel || isEmbeddedPreview();
+
+if (shouldRunToolbar) {
   const warn = (...message) => require('@common').warn`
   ${String.raw(...message)}
 

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -6,11 +6,12 @@ import { Preview } from './preview';
 import { Prediction } from './prediction';
 import { Analytics } from './analytics';
 import { PreviewCookie } from './preview/cookie';
+import { isEmbeddedPreview, setupEmbeddedPreview } from './embedded-preview';
 
 const version = process.env.npm_package_version;
 const IS_EMBEDDED = window.self !== window.top;
 
-if (!IS_EMBEDDED) {
+if (!IS_EMBEDDED || isEmbeddedPreview()) {
   const warn = (...message) => require('@common').warn`
   ${String.raw(...message)}
 
@@ -77,6 +78,15 @@ if (!IS_EMBEDDED) {
 
     setupDomain = domain;
 
+    if (isEmbeddedPreview()) {
+      const previewCookieHelper = new PreviewCookie(false, domain);
+      const preview = new Preview({
+        closePreviewSession: async () => {},
+      }, previewCookieHelper, {});
+      setupEmbeddedPreview({ preview });
+      return;
+    }
+
     const protocol = domain.match('.test$') ? window.location.protocol : 'https:';
     const toolbarClient = await ToolbarService.getClient(`${protocol}//${domain}/prismic-toolbar/${version}/iframe.html`);
     const previewState = await toolbarClient.getPreviewState();
@@ -90,6 +100,7 @@ if (!IS_EMBEDDED) {
     // Start concurrently preview (always) and prediction (if authenticated)
     const { initialRef, upToDate, isActive } = await preview.setup();
     const { convertedLegacy } = previewCookieHelper.init(initialRef);
+    setupEmbeddedPreview({ preview });
 
     if (convertedLegacy || !upToDate) {
       reloadOrigin();

--- a/src/toolbar/preview/index.js
+++ b/src/toolbar/preview/index.js
@@ -53,18 +53,21 @@ export class Preview {
 
   async updatePreview() {
     const { reload, ref } = await this.client.updatePreview();
-    this.updateFromRef(ref, { notify: reload });
+    this.start(ref);
+    if (reload) this.reloadPreview(ref);
   }
 
-  async updateFromRef(ref, { notify = true } = {}) {
+  async updateFromRef(ref) {
     const { shouldReload } = await this.start(ref);
 
-    if (notify && shouldReload) {
-      // Dispatch the update event and hard reload if not cancelled by handlers
-      if (dispatchToolbarEvent(toolbarEvents.previewUpdate, { ref })) {
-        this.cancelPreviewUpdates();
-        reloadOrigin();
-      }
+    if (shouldReload) this.reloadPreview(ref);
+  }
+
+  reloadPreview(ref) {
+    // Dispatch the update event and hard reload if not cancelled by handlers
+    if (dispatchToolbarEvent(toolbarEvents.previewUpdate, { ref })) {
+      this.cancelPreviewUpdates();
+      reloadOrigin();
     }
   }
 

--- a/src/toolbar/preview/index.js
+++ b/src/toolbar/preview/index.js
@@ -53,8 +53,13 @@ export class Preview {
 
   async updatePreview() {
     const { reload, ref } = await this.client.updatePreview();
-    this.start(ref);
-    if (reload) {
+    this.updateFromRef(ref, { notify: reload });
+  }
+
+  async updateFromRef(ref, { notify = true } = {}) {
+    const { shouldReload } = await this.start(ref);
+
+    if (notify && shouldReload) {
       // Dispatch the update event and hard reload if not cancelled by handlers
       if (dispatchToolbarEvent(toolbarEvents.previewUpdate, { ref })) {
         this.cancelPreviewUpdates();


### PR DESCRIPTION
Resolves: embedded website preview

### Description

Adds an embedded-preview mode so the Prismic editor can drive live website preview inside its Live Preview iframe, without third-party cookies. Non-embedded preview is unchanged.

### Checklist

- [ ] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

1. Open a document in the editor's Live Preview panel with a website preview configured.
2. Confirm the iframe renders draft content and updates on edit (soft refresh).
3. Confirm the standalone toolbar still previews normally outside the editor.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cookie attributes in iframe contexts and introduces postMessage-driven preview refs; origin checks mitigate misuse, but preview/cookie behavior in embedded HTTPS iframes is security-sensitive.
> 
> **Overview**
> Enables the Prismic toolbar to run inside the editor’s Live Preview iframe when `prismic_embed_preview=true`, so draft refs can be pushed over **postMessage** instead of relying on third-party cookies.
> 
> **Embedded mode** listens for `prismic:embedded-preview:set-ref` from an allowlisted parent origin, calls `preview.updateFromRef`, and signals readiness with `prismic:embedded-preview:ready`. Setup skips the toolbar iframe client and uses a minimal `Preview` + cookie helper path. Top-level preview behavior is unchanged.
> 
> **Cookies** now set `SameSite=None; Secure` on HTTPS when the page is in a cross-origin iframe, otherwise `SameSite=Lax` (including cookie removal in `demolishCookie`).
> 
> **Preview** refactors reload logic into `reloadPreview` and adds `updateFromRef` for message-driven updates. Version **4.1.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 031075c91e0fe405899bd1f24ee439aa6043161e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->