### PR TITLE
Use a new method to wroom (this one uses the correct instance profile…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prismic-toolbar",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "js-cookie": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",

--- a/src/iframe/preview.js
+++ b/src/iframe/preview.js
@@ -27,7 +27,7 @@ const Share = {
     const imageId = location.pathname.slice(1) + location.hash + SESSION_ID + '.jpg';
     const imageName = imageId;
     const session = await Share.getSession({ location, imageName });
-    if (!session.hasPreviewImage) Share.uploadScreenshot(imageName, blob);
+    if (!session.hasPreviewImage) Share.uploadScreenshot(imageName, blob).catch(() => {});
     return session.url;
   }, ({ href }) => href),
 
@@ -48,24 +48,27 @@ const Share = {
   },
 
   async uploadScreenshot(imageName, blob) {
-    const acl = await fetchy({
-      url: `/previews/${SESSION_ID}/acl`,
+    const uploadTarget = await fetchy({
+      url: `/v2/previews/${SESSION_ID}/upload-url`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        filename: imageName,
+        contentType: blob.type || 'image/jpeg'
+      })
     });
 
-    // Form
-    const body = new FormData();
-    body.append('key', `${acl.directory}/${imageName}`);
-    body.append('AWSAccessKeyId', acl.key);
-    body.append('acl', 'public-read');
-    body.append('policy', acl.policy);
-    body.append('signature', acl.signature);
-    body.append('Content-Type', 'image/png');
-    body.append('Cache-Control', 'max-age=315360000');
-    body.append('Content-Disposition', `inline; filename=${imageName}`);
-    body.append('file', blob);
+    const response = await fetch(uploadTarget.uploadUrl, {
+      method: uploadTarget.method,
+      headers: uploadTarget.headers,
+      body: blob
+    });
 
-    // Upload
-    return fetch(acl.url, { method: 'POST', body });
+    if (!response.ok) throw new Error('Unable to upload preview screenshot');
+
+    return response;
   }
 };
 


### PR DESCRIPTION
Use a new method to wroom (this one uses the correct instance profile creds)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the preview screenshot upload contract and depends on the new `/v2/previews/.../upload-url` backend; failures are partially swallowed in share flow so screenshots may be missing without blocking the share link.
> 
> **Overview**
> **Preview share screenshots** no longer upload via the legacy `/previews/:id/acl` + S3 `FormData` POST flow. `uploadScreenshot` now requests a target from **`POST /v2/previews/:sessionId/upload-url`** (filename + content type), then uploads the blob with the returned URL, method, and headers. Failed uploads throw; **`Share.run`** still returns the share URL and **ignores upload failures** via `.catch(() => {})`.
> 
> Package version is bumped to **4.1.3** in `package.json` and `package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d85fe44f6cd1cbc9b2335a72a13bc4b015e94228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->