### PR TITLE
feat(preview): support embedded poll and push modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prismic-toolbar",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "js-cookie": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.1.4",
+  "version": "4.1.3",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prismic-toolbar",
-  "version": "4.1.3",
+  "version": "4.1.5",
   "description": "Prismic Toolbar",
   "license": "Apache-2.0",
   "main": "build/prismic-toolbar.js",

--- a/src/common/cookie.js
+++ b/src/common/cookie.js
@@ -15,7 +15,7 @@ export function setCookie(name, value, expires = Infinity /* days */) {
 
 export function deleteCookie(name) {
   const path = '/';
-  Cookies.remove(name, { path });
+  Cookies.remove(name, { path, ...getSameSiteAttributes() });
 }
 
 // TODO remove after we force no /preview route (url prediction)

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -1,4 +1,7 @@
-const markerParam = 'prismic_embed_preview';
+import { deleteCookie, getCookie, setCookie } from '@common';
+
+const markerWindowName = 'prismic:embedded-preview';
+const previewCookieName = 'io.prismic.preview';
 
 const setRefMessageType = 'prismic:embedded-preview:set-ref';
 const readyMessageType = 'prismic:embedded-preview:ready';
@@ -21,8 +24,22 @@ const devParentOrigins = [
 export function isEmbeddedPreview() {
   return (
     window.self !== window.top
-    && new URLSearchParams(window.location.search).get(markerParam) === 'true'
+    && window.name === markerWindowName
   );
+}
+
+export class EmbeddedPreviewCookie {
+  getRefForDomain() {
+    return getCookie(previewCookieName);
+  }
+
+  upsertPreviewForDomain(ref) {
+    setCookie(previewCookieName, ref);
+  }
+
+  deletePreviewForDomain() {
+    deleteCookie(previewCookieName);
+  }
 }
 
 export function setupEmbeddedPreview({ preview }) {

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -1,6 +1,7 @@
 import { deleteCookie, getCookie, setCookie } from '@common';
 
-const markerWindowName = 'prismic:embedded-preview';
+const pushMarkerWindowName = 'prismic:embedded-preview';
+const pollMarkerWindowName = 'prismic:embedded-preview:poll';
 const previewCookieName = 'io.prismic.preview';
 
 const setRefMessageType = 'prismic:embedded-preview:set-ref';
@@ -22,13 +23,25 @@ const devParentOrigins = [
 ];
 
 export function isEmbeddedPreview() {
-  return (
-    window.self !== window.top
-    && window.name === markerWindowName
-  );
+  return Boolean(getEmbeddedPreviewMode());
+}
+
+export function getEmbeddedPreviewMode() {
+  if (window.self === window.top) return;
+  if (window.name === pushMarkerWindowName) return 'push';
+  if (window.name === pollMarkerWindowName) return 'poll';
 }
 
 export class EmbeddedPreviewCookie {
+  init(ref) {
+    if (ref === this.getRefForDomain()) return { convertedLegacy: false };
+
+    if (ref) this.upsertPreviewForDomain(ref);
+    else this.deletePreviewForDomain();
+
+    return { convertedLegacy: false };
+  }
+
   getRefForDomain() {
     return getCookie(previewCookieName);
   }
@@ -42,9 +55,10 @@ export class EmbeddedPreviewCookie {
   }
 }
 
-export function setupEmbeddedPreview({ preview }) {
+export function setupEmbeddedPreviewPush({ preview }) {
   window.addEventListener('message', event => {
     if (!isAllowedParentOrigin(event.origin)) return;
+    if (event.source !== window.parent) return;
     if (!isSetRefMessage(event.data)) return;
 
     preview.updateFromRef(event.data.token).catch(error => {

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -7,6 +7,7 @@ const previewCookieName = 'io.prismic.preview';
 const setRefMessageType = 'prismic:embedded-preview:set-ref';
 const readyMessageType = 'prismic:embedded-preview:ready';
 
+// Only used by the push message handler (embedded previews).
 const allowedParentOrigins = [
   /^https:\/\/([^/]+\.)?prismic\.io$/,
   /^https:\/\/([^/]+\.)?wroom\.io$/,
@@ -15,16 +16,9 @@ const allowedParentOrigins = [
   /^https:\/\/([^/]+\.)?platform-wroom\.com$/,
   /^https:\/\/([^/]+\.)?devops-wroom\.com$/,
   /^https:\/\/[a-z0-9-]+-prismic\.vercel\.app$/,
-];
-
-const devParentOrigins = [
   /^http:\/\/localhost:\d+$/,
   /^http:\/\/127\.0\.0\.1:\d+$/,
 ];
-
-export function isEmbeddedPreview() {
-  return Boolean(getEmbeddedPreviewMode());
-}
 
 export function getEmbeddedPreviewMode() {
   if (window.self === window.top) return;
@@ -84,11 +78,5 @@ function isSetRefMessage(data) {
 
 function isAllowedParentOrigin(origin) {
   if (!origin) return false;
-
-  const allowed = [
-    ...allowedParentOrigins,
-    ...(isEmbeddedPreview() ? devParentOrigins : []),
-  ];
-
-  return allowed.some(allowedOrigin => allowedOrigin.test(origin));
+  return allowedParentOrigins.some(allowedOrigin => allowedOrigin.test(origin));
 }

--- a/src/toolbar/embedded-preview.js
+++ b/src/toolbar/embedded-preview.js
@@ -33,13 +33,14 @@ export function getEmbeddedPreviewMode() {
 }
 
 export class EmbeddedPreviewCookie {
-  init(ref) {
-    if (ref === this.getRefForDomain()) return { convertedLegacy: false };
+  // Align the site cookie with `ref`. Returns true when the page should reload.
+  sync(ref) {
+    if (ref === this.getRefForDomain()) return false;
 
     if (ref) this.upsertPreviewForDomain(ref);
     else this.deletePreviewForDomain();
 
-    return { convertedLegacy: false };
+    return true;
   }
 
   getRefForDomain() {

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -106,11 +106,10 @@ if (shouldRunToolbar) {
       : new PreviewCookie(previewState.auth, toolbarClient.hostname);
     const preview = new Preview(toolbarClient, previewCookieHelper, previewState);
 
-    // Initialize preview state before reconciling its cookie.
-    const { initialRef, upToDate, isActive } = await preview.setup();
-    const { convertedLegacy } = previewCookieHelper.init(initialRef);
+    const { initialRef, isActive } = await preview.setup();
 
-    if (convertedLegacy || !upToDate) {
+    // Skip cookie sync when inactive so we don't clear a preview owned by another tab.
+    if (isActive && previewCookieHelper.sync(initialRef)) {
       reloadOrigin();
       return;
     }
@@ -138,9 +137,6 @@ if (shouldRunToolbar) {
     }
 
     if (!isActive) {
-      if (previewCookieHelper.getRefForDomain())
-        previewCookieHelper.deletePreviewForDomain();
-
       await toolbarClient.closePreviewSession();
     }
   }

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -8,15 +8,19 @@ import { Analytics } from './analytics';
 import { PreviewCookie } from './preview/cookie';
 import {
   EmbeddedPreviewCookie,
-  isEmbeddedPreview,
-  setupEmbeddedPreview,
+  getEmbeddedPreviewMode,
+  setupEmbeddedPreviewPush,
 } from './embedded-preview';
 
 const version = process.env.npm_package_version;
 const isTopLevel = window.self === window.top;
+const embeddedPreviewMode = getEmbeddedPreviewMode();
+const isEmbeddedPushPreview = embeddedPreviewMode === 'push';
+const isEmbeddedPollPreview = embeddedPreviewMode === 'poll';
+const isRegularToolbar = embeddedPreviewMode === undefined;
 
 // Run at the top level, or inside the editor's embedded preview iframe
-const shouldRunToolbar = isTopLevel || isEmbeddedPreview();
+const shouldRunToolbar = isTopLevel || Boolean(embeddedPreviewMode);
 
 if (shouldRunToolbar) {
   const warn = (...message) => require('@common').warn`
@@ -85,27 +89,24 @@ if (shouldRunToolbar) {
 
     setupDomain = domain;
 
-    if (isEmbeddedPreview()) {
-      // Refs arrive via set-ref messages; the stub client only guards Preview.end()
+    if (isEmbeddedPushPreview) {
       const previewCookieHelper = new EmbeddedPreviewCookie();
       const preview = new Preview({
         closePreviewSession: async () => {},
       }, previewCookieHelper, {});
-      setupEmbeddedPreview({ preview });
+      setupEmbeddedPreviewPush({ preview });
       return;
     }
 
     const protocol = domain.match('.test$') ? window.location.protocol : 'https:';
     const toolbarClient = await ToolbarService.getClient(`${protocol}//${domain}/prismic-toolbar/${version}/iframe.html`);
     const previewState = await toolbarClient.getPreviewState();
-    const previewCookieHelper = new PreviewCookie(previewState.auth, toolbarClient.hostname);
-    // convert from legacy or clean the cookie if not authenticated
+    const previewCookieHelper = isEmbeddedPollPreview
+      ? new EmbeddedPreviewCookie()
+      : new PreviewCookie(previewState.auth, toolbarClient.hostname);
     const preview = new Preview(toolbarClient, previewCookieHelper, previewState);
 
-    const prediction = previewState.auth && new Prediction(toolbarClient, previewCookieHelper);
-    const analytics = previewState.auth && new Analytics(toolbarClient);
-
-    // Start concurrently preview (always) and prediction (if authenticated)
+    // Initialize preview state before reconciling its cookie.
     const { initialRef, upToDate, isActive } = await preview.setup();
     const { convertedLegacy } = previewCookieHelper.init(initialRef);
 
@@ -114,8 +115,15 @@ if (shouldRunToolbar) {
       return;
     }
 
-    if (isActive || previewState.auth) {
-    // eslint-disable-next-line no-undef
+    if (isRegularToolbar && (isActive || previewState.auth)) {
+      const prediction = previewState.auth
+        ? new Prediction(toolbarClient, previewCookieHelper)
+        : undefined;
+      const analytics = previewState.auth
+        ? new Analytics(toolbarClient)
+        : undefined;
+
+      // eslint-disable-next-line no-undef
       await script(`${CDN_HOST}/prismic-toolbar/${version}/toolbar.js`);
       new window.prismic.Toolbar({
         displayPreview: isActive,

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -6,7 +6,11 @@ import { Preview } from './preview';
 import { Prediction } from './prediction';
 import { Analytics } from './analytics';
 import { PreviewCookie } from './preview/cookie';
-import { isEmbeddedPreview, setupEmbeddedPreview } from './embedded-preview';
+import {
+  EmbeddedPreviewCookie,
+  isEmbeddedPreview,
+  setupEmbeddedPreview,
+} from './embedded-preview';
 
 const version = process.env.npm_package_version;
 const isTopLevel = window.self === window.top;
@@ -83,7 +87,7 @@ if (shouldRunToolbar) {
 
     if (isEmbeddedPreview()) {
       // Refs arrive via set-ref messages; the stub client only guards Preview.end()
-      const previewCookieHelper = new PreviewCookie(/* auth */ false, domain);
+      const previewCookieHelper = new EmbeddedPreviewCookie();
       const preview = new Preview({
         closePreviewSession: async () => {},
       }, previewCookieHelper, {});

--- a/src/toolbar/preview/cookie.js
+++ b/src/toolbar/preview/cookie.js
@@ -10,30 +10,23 @@ export class PreviewCookie {
     this.domain = domain;
   }
 
-  init(ref) {
-    const hasConvertCookie = this.makeConvertLegacy();
-    if (hasConvertCookie) return { convertedLegacy: true };
+  // Align the site cookie with `ref`. Returns true when the page should reload.
+  sync(ref) {
+    if (this.convertLegacyCookieIfNeeded()) return true;
 
-    const tracker = (() => {
-      const c = this.get();
-      return c && c._tracker;
-    })();
-    const value = this.build({ tracker, preview: ref });
-    this.set(value);
-    return { convertedLegacy: false };
+    const upToDate = ref === this.getRefForDomain();
+    this.upsertPreviewForDomain(ref);
+    return !upToDate;
   }
 
-  makeConvertLegacy() {
+  convertLegacyCookieIfNeeded() {
     const cookieOpt = getCookie(PREVIEW_COOKIE_NAME);
-    if (cookieOpt) {
-      const parsedCookie = (() => {
-        try {
-          return JSON.parse(cookieOpt);
-        } catch (e) {
-          return null;
-        }
-      })();
-      if (parsedCookie) return false;
+    if (!cookieOpt) return false;
+
+    try {
+      JSON.parse(cookieOpt);
+      return false;
+    } catch (e) {
       this.convertLegacyCookie(cookieOpt);
       return true;
     }

--- a/src/toolbar/preview/index.js
+++ b/src/toolbar/preview/index.js
@@ -22,27 +22,20 @@ export class Preview {
     this.documents = preview.documents || [];
 
     const refUpToDate = preview.ref === this.cookie.getRefForDomain();
-    const displayPreview = this.active && refUpToDate;
-    // We don't display the preview by default unless the start function says so
-    if (displayPreview) this.watchPreviewUpdates();
+    // Start polling only when the cookie already matches; otherwise sync + reload will.
+    if (this.active && refUpToDate) this.watchPreviewUpdates();
 
     return {
       isActive: this.active,
       initialRef: preview.ref,
-      upToDate: refUpToDate
     };
   };
 
   watchPreviewUpdates() {
     if (this.active) {
       this.interval = setInterval(() => {
-        if (document.visibilityState === 'visible') {
-          if (this.cookie.getRefForDomain()) {
-            this.updatePreview();
-          } else {
-            this.end();
-          }
-        }
+        // End only on a falsy ping ref (via start → end), not a missing site cookie.
+        if (document.visibilityState === 'visible') this.updatePreview();
       }, 3000);
     }
   }


### PR DESCRIPTION
Resolves: CT-24

### Description

Adds poll and push transports for editor-embedded website previews while keeping the regular Toolbar behavior unchanged.

- Detects the embedded transport through the iframe's `window.name`, preserving the existing push marker.
- Reuses the regular preview client, session state, and update polling in poll mode.
- Keeps the Toolbar UI, prediction, and analytics disabled in embedded previews.
- Validates both the parent origin and message source before accepting pushed refs.
- Removes embedded preview cookies with the same `SameSite` and `Secure` attributes used when setting them.
- Avoids tearing down a shared `io.prismic.preview` cookie when another tab/iframe still owns the preview:
  - poll loop ends only on a falsy ping ref, not a missing site cookie
  - inactive toolbar setup no longer deletes/rewrites the site preview cookie
- Replaces cookie `init` / `convertedLegacy` with `sync(ref)` → reload boolean.
- Bumps the Toolbar version to 4.1.5.

This change is coordinated with prismicio/editor#2414.

### Checklist

- [ ] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A — embedded preview modes intentionally keep the Toolbar UI hidden.

### How to QA [^1]

1. Run `npm run lint`.
2. Run `CDN_HOST=http://localhost:8081 npm run build:prod` and serve the generated Toolbar assets.
3. In embedded poll mode (`window.name = "prismic:embedded-preview:poll"`), verify the website preview opens and updates through the regular preview session polling path.
4. In embedded push mode (`window.name = "prismic:embedded-preview"`), verify ref updates from the editor refresh the website preview.
5. Open a website outside the editor and verify the regular Toolbar UI and preview behavior are unchanged.
6. End an embedded preview and verify the preview cookie is removed without a reload loop.
7. With an embedded poll preview open, open the same site in a standalone preview tab and verify both stay on the draft ref (neither falls back to master / `/api/exit-preview` from shared cookie teardown).

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preview cookie lifecycle and embedded iframe messaging, which affect draft ref consistency across tabs and editor embeds; regular top-level toolbar paths are mostly gated but behavior around inactive sessions and cookie deletion is different.
> 
> **Overview**
> Adds **embedded poll and push** preview transports for editor iframes (via `window.name`), bumps the package to **4.1.5**, and tightens preview cookie handling for multi-tab/embedded use.
> 
> Embedded mode is detected with `getEmbeddedPreviewMode()` (`prismic:embedded-preview` = push, `prismic:embedded-preview:poll` = poll) instead of a URL query flag. **Push** uses `setupEmbeddedPreviewPush` with parent origin checks plus `event.source === window.parent`, and `EmbeddedPreviewCookie` for the preview ref. **Poll** keeps the normal preview client/session polling but uses the same simple cookie helper. Toolbar UI, prediction, and analytics load only when `isRegularToolbar` is true.
> 
> Cookie work: `deleteCookie` passes the same `SameSite`/`Secure` options as `setCookie`. `PreviewCookie` drops `init` in favor of **`sync(ref)`** (legacy conversion + align cookie; returns whether to reload). Setup reloads only when preview is active and `sync` says so, and no longer clears the preview cookie when inactive. Preview polling no longer ends just because the site cookie is missing (only on a falsy ping ref).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122da43f12159cb5542a3ceb524d106683a5b6e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->