### PR TITLE
feat(preview): report the previewed website's height to the editor

### DIFF
--- a/src/toolbar/embedded-preview/document-height.js
+++ b/src/toolbar/embedded-preview/document-height.js
@@ -65,6 +65,7 @@ function start(parentOrigin) {
       if (viewportDrivenGrowths >= maxViewportDrivenGrowths) {
         isViewportDriven = true;
         setPageScrolling(true);
+        heightToPost = undefined;
         post(null);
         return;
       }

--- a/src/toolbar/embedded-preview/document-height.js
+++ b/src/toolbar/embedded-preview/document-height.js
@@ -21,7 +21,6 @@ function start(parentOrigin) {
   let heightToPost;
   let viewportDrivenGrowths = 0;
   let isViewportDriven = false;
-  setPageScrolling(false);
 
   const post = height =>
     window.parent.postMessage(
@@ -64,7 +63,6 @@ function start(parentOrigin) {
 
       if (viewportDrivenGrowths >= maxViewportDrivenGrowths) {
         isViewportDriven = true;
-        setPageScrolling(true);
         heightToPost = undefined;
         post(null);
         return;
@@ -85,12 +83,6 @@ function start(parentOrigin) {
   if (document.fonts) document.fonts.ready.then(measure);
 
   measure();
-}
-
-function setPageScrolling(enabled) {
-  const overflow = enabled ? '' : 'hidden';
-  document.documentElement.style.overflow = overflow;
-  document.body.style.overflow = overflow;
 }
 
 function measureDocumentHeight() {

--- a/src/toolbar/embedded-preview/document-height.js
+++ b/src/toolbar/embedded-preview/document-height.js
@@ -1,0 +1,107 @@
+import { throttle } from '@common';
+
+const documentHeightMessageType = 'prismic:embedded-preview:document-height';
+
+const postInterval = 100;
+
+// A page whose height grows with the viewport (e.g. a 100vh hero above other
+// content) grows again every time the editor applies the height we report. The
+// signature is a height growing along with the viewport, repeatedly: content
+// loading late (lazy images, fonts) does it once, a viewport-sized page forever.
+const viewportDrivenGrowthRatio = 0.5;
+const maxViewportDrivenGrowths = 3;
+
+export function startDocumentHeightReporting({ parentOrigin }) {
+  if (document.body) start(parentOrigin);
+  else window.addEventListener('DOMContentLoaded', () => start(parentOrigin));
+}
+
+function start(parentOrigin) {
+  let lastMeasure;
+  let heightToPost;
+  let viewportDrivenGrowths = 0;
+  let isViewportDriven = false;
+  setPageScrolling(false);
+
+  const post = height =>
+    window.parent.postMessage(
+      { type: documentHeightMessageType, height },
+      parentOrigin,
+    );
+
+  const postSoon = throttle(() => {
+    if (heightToPost === undefined) return;
+
+    post(heightToPost);
+    heightToPost = undefined;
+  }, postInterval);
+
+  // Measuring on every observed change, never on a delay, is what keeps the
+  // growth detection honest: the editor sets the viewport to the height we post,
+  // so batching that change together with any other one makes the two
+  // indistinguishable from a page that grows with its viewport.
+  const measure = () => {
+    if (isViewportDriven) return;
+
+    const height = measureDocumentHeight();
+    const { innerHeight: viewportHeight, innerWidth: viewportWidth } = window;
+    const previous = lastMeasure;
+    lastMeasure = { height, viewportHeight, viewportWidth };
+
+    if (previous) {
+      const viewportGrowth = viewportHeight - previous.viewportHeight;
+      const heightGrowth = height - previous.height;
+      // A width change reflows the page, which changes its height for reasons
+      // that have nothing to do with the viewport height.
+      const isReflow = viewportWidth !== previous.viewportWidth;
+      const isViewportDrivenGrowth = !isReflow
+        && viewportGrowth > 0
+        && heightGrowth >= viewportGrowth * viewportDrivenGrowthRatio;
+
+      viewportDrivenGrowths = isViewportDrivenGrowth
+        ? viewportDrivenGrowths + 1
+        : 0;
+
+      if (viewportDrivenGrowths >= maxViewportDrivenGrowths) {
+        isViewportDriven = true;
+        setPageScrolling(true);
+        post(null);
+        return;
+      }
+
+      if (heightGrowth === 0) return;
+    }
+
+    heightToPost = height;
+    postSoon();
+  };
+
+  const observer = new ResizeObserver(measure);
+  observer.observe(document.documentElement);
+  observer.observe(document.body);
+
+  window.addEventListener('load', measure);
+  if (document.fonts) document.fonts.ready.then(measure);
+
+  measure();
+}
+
+function setPageScrolling(enabled) {
+  const overflow = enabled ? '' : 'hidden';
+  document.documentElement.style.overflow = overflow;
+  document.body.style.overflow = overflow;
+}
+
+function measureDocumentHeight() {
+  const { marginTop, marginBottom } = window.getComputedStyle(document.body);
+  const margins = (parseFloat(marginTop) || 0) + (parseFloat(marginBottom) || 0);
+
+  // `scrollHeight` is rounded and covers overflowing children, while the rect is
+  // exact. Taking both and rounding up avoids a sub-pixel scrollbar.
+  const height = Math.max(
+    document.body.scrollHeight,
+    document.body.getBoundingClientRect().height,
+  );
+
+  return Math.ceil(height + margins);
+}

--- a/src/toolbar/embedded-preview/index.js
+++ b/src/toolbar/embedded-preview/index.js
@@ -1,3 +1,6 @@
+import { once } from '@common';
+import { startDocumentHeightReporting } from './document-height';
+
 const markerParam = 'prismic_embed_preview';
 
 const setRefMessageType = 'prismic:embedded-preview:set-ref';
@@ -26,6 +29,8 @@ export function isEmbeddedPreview() {
 }
 
 export function setupEmbeddedPreview({ preview }) {
+  const startHeightReporting = once(parentOrigin => startDocumentHeightReporting({ parentOrigin }));
+
   window.addEventListener('message', event => {
     if (!isAllowedParentOrigin(event.origin)) return;
     if (!isSetRefMessage(event.data)) return;
@@ -33,6 +38,9 @@ export function setupEmbeddedPreview({ preview }) {
     preview.updateFromRef(event.data.token).catch(error => {
       console.error('Failed to update embedded preview ref.', error);
     });
+
+    // The parent origin is only known once it has posted a valid message to us.
+    startHeightReporting(event.origin);
   });
 
   // Safe to broadcast to '*': no data in this message, and both sides

--- a/src/toolbar/embedded-preview/index.js
+++ b/src/toolbar/embedded-preview/index.js
@@ -52,50 +52,34 @@ export class EmbeddedPreviewCookie {
 }
 
 export function setupEmbeddedPreviewPush({ preview }) {
-  const startHeightReporting = onceStartDocumentHeightReporting();
-
-  listenToParent(event => {
+  connectToParent(event => {
     if (!isSetRefMessage(event.data)) return;
 
     preview.updateFromRef(event.data.token).catch(error => {
       console.error('Failed to update embedded preview ref.', error);
     });
-
-    startHeightReporting(event.origin);
   });
-
-  postReadyMessage();
 }
 
-// Poll mode gets its ref on its own, so the editor only replies to say it's
-// there, which is what reveals its origin to us.
 export function setupEmbeddedPreviewPoll() {
-  const startHeightReporting = onceStartDocumentHeightReporting();
-
-  listenToParent(event => {
-    if (!isTypedMessage(event.data, ackMessageType)) return;
-
-    startHeightReporting(event.origin);
-  });
-
-  postReadyMessage();
+  connectToParent();
 }
 
-function onceStartDocumentHeightReporting() {
-  // The parent origin is only known once it has posted a valid message to us.
-  return once(parentOrigin => startDocumentHeightReporting({ parentOrigin }));
-}
+function connectToParent(handleMessage = () => {}) {
+  const startHeightReporting = once(parentOrigin => startDocumentHeightReporting({ parentOrigin }));
 
-function listenToParent(handler) {
   window.addEventListener('message', event => {
     if (!isAllowedParentOrigin(event.origin)) return;
     if (event.source !== window.parent) return;
 
-    handler(event);
-  });
-}
+    if (isTypedMessage(event.data, ackMessageType)) {
+      startHeightReporting(event.origin);
+      return;
+    }
 
-function postReadyMessage() {
+    handleMessage(event);
+  });
+
   // Safe to broadcast to '*': no data in this message, and both sides
   // validate origins on the messages that follow.
   window.parent.postMessage({ type: readyMessageType }, '*');

--- a/src/toolbar/embedded-preview/index.js
+++ b/src/toolbar/embedded-preview/index.js
@@ -7,8 +7,8 @@ const previewCookieName = 'io.prismic.preview';
 
 const setRefMessageType = 'prismic:embedded-preview:set-ref';
 const readyMessageType = 'prismic:embedded-preview:ready';
+const ackMessageType = 'prismic:embedded-preview:ack';
 
-// Only used by the push message handler (embedded previews).
 const allowedParentOrigins = [
   /^https:\/\/([^/]+\.)?prismic\.io$/,
   /^https:\/\/([^/]+\.)?wroom\.io$/,
@@ -52,40 +52,65 @@ export class EmbeddedPreviewCookie {
 }
 
 export function setupEmbeddedPreviewPush({ preview }) {
-  const startHeightReporting = once(parentOrigin => startDocumentHeightReporting({ parentOrigin }));
+  const startHeightReporting = onceStartDocumentHeightReporting();
 
-  window.addEventListener('message', event => {
-    if (!isAllowedParentOrigin(event.origin)) return;
-    if (event.source !== window.parent) return;
+  listenToParent(event => {
     if (!isSetRefMessage(event.data)) return;
 
     preview.updateFromRef(event.data.token).catch(error => {
       console.error('Failed to update embedded preview ref.', error);
     });
 
-    // The parent origin is only known once it has posted a valid message to us.
     startHeightReporting(event.origin);
   });
 
-  // Safe to broadcast to '*': no data in this message, and both sides
-  // validate origins on the ref messages that follow.
-  window.parent.postMessage({ type: readyMessageType }, '*');
+  postReadyMessage();
 }
 
+// Poll mode gets its ref on its own, so the editor only replies to say it's
+// there, which is what reveals its origin to us.
 export function setupEmbeddedPreviewPoll() {
-  // Poll mode never receives a message from the parent, so its origin is
-  // unknown. Broadcasting is safe here: the message only carries a height.
-  startDocumentHeightReporting({ parentOrigin: '*' });
+  const startHeightReporting = onceStartDocumentHeightReporting();
+
+  listenToParent(event => {
+    if (!isTypedMessage(event.data, ackMessageType)) return;
+
+    startHeightReporting(event.origin);
+  });
+
+  postReadyMessage();
+}
+
+function onceStartDocumentHeightReporting() {
+  // The parent origin is only known once it has posted a valid message to us.
+  return once(parentOrigin => startDocumentHeightReporting({ parentOrigin }));
+}
+
+function listenToParent(handler) {
+  window.addEventListener('message', event => {
+    if (!isAllowedParentOrigin(event.origin)) return;
+    if (event.source !== window.parent) return;
+
+    handler(event);
+  });
+}
+
+function postReadyMessage() {
+  // Safe to broadcast to '*': no data in this message, and both sides
+  // validate origins on the messages that follow.
+  window.parent.postMessage({ type: readyMessageType }, '*');
 }
 
 function isSetRefMessage(data) {
   return (
-    data
-    && typeof data === 'object'
-    && data.type === setRefMessageType
+    isTypedMessage(data, setRefMessageType)
     && typeof data.token === 'string'
     && data.token.length > 0
   );
+}
+
+function isTypedMessage(data, type) {
+  return Boolean(data) && typeof data === 'object' && data.type === type;
 }
 
 function isAllowedParentOrigin(origin) {

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -99,6 +99,8 @@ if (shouldRunToolbar) {
       return;
     }
 
+    if (isEmbeddedPollPreview) setupEmbeddedPreviewPoll();
+
     const protocol = domain.match('.test$') ? window.location.protocol : 'https:';
     const toolbarClient = await ToolbarService.getClient(`${protocol}//${domain}/prismic-toolbar/${version}/iframe.html`);
     const previewState = await toolbarClient.getPreviewState();
@@ -114,8 +116,6 @@ if (shouldRunToolbar) {
       reloadOrigin();
       return;
     }
-
-    if (isEmbeddedPollPreview) setupEmbeddedPreviewPoll();
 
     if (isRegularToolbar && (isActive || previewState.auth)) {
       const prediction = previewState.auth


### PR DESCRIPTION
## Context

Closes [CT-28](https://linear.app/prismic/issue/CT-28/measuring-the-website).

The editor's live preview embeds the customer's website in an iframe. That iframe was sized to the space available in the editor and scrolled internally, so the editor never knew how tall the previewed page actually was. That prevents the editor from scrolling the page as a whole, and it blocks stable overlays on top of the preview (comments, slice highlighting), since nothing can be positioned against a page whose real size is unknown.

## What this does

The toolbar now measures the previewed page and reports its height to the editor, which sizes the iframe to fit the whole page. The website itself no longer scrolls — the editor's container does.

The height is kept up to date as the page changes: content edits, switching between desktop/tablet/mobile widths, and late-loading images or fonts.

## How it works

A new `document-height.js` module posts `prismic:embedded-preview:document-height` to the parent, alongside the existing `ready`/`set-ref` messages. Notable decisions:

- **Origin.** Reporting starts on the first trusted `set-ref` message and reuses that origin, so heights are never broadcast to `'*'`.
- **Measurement.** `body.scrollHeight` is an integer, so a page that is really `4073.17px` tall would leave a fraction of overflow and a scrollbar that scrolls nothing. The measurement takes the larger of `scrollHeight` and the exact bounding rect, then rounds up.
- **No scrollbar in the frame.** The toolbar hides the page's own scrolling from the inside. Doing it here avoids the deprecated `scrolling="no"` attribute on the editor's iframe, whose CSS replacement has never worked in Chrome or Safari. It also means the page is measured at its true width.
- **Pages with no stable height.** A `100vh` hero above other content solves as `height = viewport + rest`, so feeding the reported height back as the viewport grows it forever — there is no correct answer for such a page. When the height grows in step with the viewport three times in a row, the toolbar restores the page's scrolling and reports `null`, and the editor falls back to today's viewport-sized iframe.
- **Measure eagerly, post lazily.** Since the editor sets the viewport to exactly the height we report, batching a resize together with the editor applying a height makes a real reflow indistinguishable from the growth loop above. Every observed change is measured immediately; only the posting is throttled.

## Side notes

`embedded-preview.js` became a folder (`embedded-preview/index.js` plus `document-height.js`), matching `preview/` and `experiment/`. The import in `src/toolbar/index.js` is unchanged.

The editor half of this change lives in a separate PR in the `editor` repo.


Before:

https://github.com/user-attachments/assets/c823b6b0-0711-4248-b81e-0f7e09b79531

After:


https://github.com/user-attachments/assets/41ef3ff0-8cd4-4f94-a836-1a5553874ef9

