### PR TITLE
feat(preview): let the parent force a reload on a stable preview ref

### DIFF
--- a/src/toolbar/embedded-preview/index.js
+++ b/src/toolbar/embedded-preview/index.js
@@ -6,6 +6,7 @@ const pollMarkerWindowName = 'prismic:embedded-preview:poll';
 const previewCookieName = 'io.prismic.preview';
 
 const setRefMessageType = 'prismic:embedded-preview:set-ref';
+const reloadMessageType = 'prismic:embedded-preview:reload';
 const readyMessageType = 'prismic:embedded-preview:ready';
 const ackMessageType = 'prismic:embedded-preview:ack';
 
@@ -53,11 +54,22 @@ export class EmbeddedPreviewCookie {
 
 export function setupEmbeddedPreviewPush({ preview }) {
   connectToParent(event => {
-    if (!isSetRefMessage(event.data)) return;
+    if (isSetRefMessage(event.data)) {
+      preview.updateFromRef(event.data.token).catch(error => {
+        console.error('Failed to update embedded preview ref.', error);
+      });
+      return;
+    }
 
-    preview.updateFromRef(event.data.token).catch(error => {
-      console.error('Failed to update embedded preview ref.', error);
-    });
+    // `set-ref` only reloads when the ref itself changes, because `start` treats an
+    // unchanged ref as "already previewing this". That holds when every new snapshot
+    // gets its own ref, but not when a preview session keeps one stable ref for its
+    // whole life and the content behind it is what moves. In that case a repeated
+    // `set-ref` is a no-op and the page keeps rendering the snapshot it loaded with.
+    // This message lets the parent say "same ref, new content" explicitly.
+    if (isTypedMessage(event.data, reloadMessageType)) {
+      preview.reloadEmbeddedPreview();
+    }
   });
 }
 

--- a/src/toolbar/embedded-preview/index.js
+++ b/src/toolbar/embedded-preview/index.js
@@ -58,16 +58,8 @@ export function setupEmbeddedPreviewPush({ preview }) {
       preview.updateFromRef(event.data.token).catch(error => {
         console.error('Failed to update embedded preview ref.', error);
       });
-      return;
-    }
-
-    // `set-ref` only reloads when the ref itself changes, because `start` treats an
-    // unchanged ref as "already previewing this". That holds when every new snapshot
-    // gets its own ref, but not when a preview session keeps one stable ref for its
-    // whole life and the content behind it is what moves. In that case a repeated
-    // `set-ref` is a no-op and the page keeps rendering the snapshot it loaded with.
-    // This message lets the parent say "same ref, new content" explicitly.
-    if (isTypedMessage(event.data, reloadMessageType)) {
+    } else if (isTypedMessage(event.data, reloadMessageType)) {
+      // Reload when the content behind a stable preview ref changes.
       preview.reloadEmbeddedPreview();
     }
   });

--- a/src/toolbar/preview/index.js
+++ b/src/toolbar/preview/index.js
@@ -56,9 +56,6 @@ export class Preview {
     if (shouldReload) this.reloadPreview(ref);
   }
 
-  // Reload on the ref we are already previewing. Used when the content behind a
-  // stable ref changed, which `updateFromRef` cannot detect. No-op when no preview
-  // cookie is set, so a stray message cannot reload a page that isn't previewing.
   reloadEmbeddedPreview() {
     const ref = this.cookie.getRefForDomain();
 

--- a/src/toolbar/preview/index.js
+++ b/src/toolbar/preview/index.js
@@ -56,6 +56,15 @@ export class Preview {
     if (shouldReload) this.reloadPreview(ref);
   }
 
+  // Reload on the ref we are already previewing. Used when the content behind a
+  // stable ref changed, which `updateFromRef` cannot detect. No-op when no preview
+  // cookie is set, so a stray message cannot reload a page that isn't previewing.
+  reloadEmbeddedPreview() {
+    const ref = this.cookie.getRefForDomain();
+
+    if (ref) this.reloadPreview(ref);
+  }
+
   reloadPreview(ref) {
     // Dispatch the update event and hard reload if not cancelled by handlers
     if (dispatchToolbarEvent(toolbarEvents.previewUpdate, { ref })) {


### PR DESCRIPTION
## Goal

Reload the current preview after new content was materialized behind a stable ref.

The Toolbar reloads whatever ref is already stored in the preview cookie. It does not need to know if the ref is legacy or `m-*:p-*`.

## Why

Legacy `set-ref` reloads only when the ref changes.

The new Content API preview keeps one stable `p-*` ref while its PostgreSQL overlay changes, so repeating `set-ref` is a no-op.

This PR adds one explicit operation: `prismic:embedded-preview:reload`.

## Behavior

- no preview cookie means no-op
- existing origin and parent-window checks still apply
- the existing cancellable `prismicPreviewUpdate` event still applies
- legacy and poll behavior stay unchanged
- existing clients never reach this branch until they send the new message

## Related PRs

- [Editor #2385](https://github.com/prismicio/editor/pull/2385) sends reload after Publication API accepts a later snapshot
- [Wroom #3222](https://github.com/prismicio/wroom/pull/3222) opens the stable preview session
- [Obelix #1798](https://github.com/prismicio/obelix/pull/1798) binds the `p-*` ref to its master

Toolbar needs to be released before enabling the Editor path. An older Toolbar can display the initial snapshot but ignores later reload messages.

## Tested

- `npm run lint`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build:prod`
- production bundle contains the reload operation
- exact bundle loaded with the Editor candidate against Platform Wroom and Obelix
- five rapid edits inside Editor's debounce produced one reload and rendered the final snapshot
- the public preview ref stayed stable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change to embedded preview messaging and reload wiring; existing set-ref and poll behavior stay the same.
> 
> **Overview**
> Adds an explicit **`prismic:embedded-preview:reload`** parent message so embedded previews can hard-reload when content changes behind the **same** preview ref (e.g. stable `p-*` refs from the Content API), where repeating **`set-ref`** is a no-op.
> 
> Push-mode embedded preview now handles **`set-ref`** and **`reload`** in one listener: **`reload`** calls **`reloadEmbeddedPreview()`**, which reads the existing preview cookie ref and runs the same cancellable **`reloadPreview`** path as ref changes—**no-op** if there is no cookie. Legacy **`set-ref`**, poll mode, and origin/parent checks are unchanged; clients that never send **`reload`** never hit the new branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9074e8d946b7fcfe70f69666196c481cdbedfcd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->