### PR TITLE
feat(preview): render comment pins in toolbar overlay

### DIFF
--- a/src/common/general.js
+++ b/src/common/general.js
@@ -21,9 +21,13 @@ export const fetchy = ({ url, ...other }) => fetch(url, other).then(r => r.json(
 export const ellipsis = (text, cutoff) =>
   text.length > cutoff ? text.substring(0, cutoff - 1) + '…' : text;
 
-// ReadyDOM - DOM Listener is useless (await X is already asynchronous)
+// Wait until the parsed DOM, including document.body, is available.
 export const readyDOM = async () => {
-  if (document.readyState !== 'complete') await wait(0);
+  if (!document.body) {
+    await new Promise(resolve => {
+      document.addEventListener('DOMContentLoaded', resolve, { once: true });
+    });
+  }
   return true;
 };
 

--- a/src/toolbar/embedded-preview/index.js
+++ b/src/toolbar/embedded-preview/index.js
@@ -1,5 +1,6 @@
 import { deleteCookie, getCookie, once, setCookie } from '@common';
 import { startDocumentHeightReporting } from './document-height';
+import { EmbeddedPreviewOverlay } from './overlay';
 
 const pushMarkerWindowName = 'prismic:embedded-preview';
 const pollMarkerWindowName = 'prismic:embedded-preview:poll';
@@ -66,17 +67,22 @@ export function setupEmbeddedPreviewPoll() {
 }
 
 function connectToParent(handleMessage = () => {}) {
-  const startHeightReporting = once(parentOrigin => startDocumentHeightReporting({ parentOrigin }));
+  let overlay;
+  const connect = once(parentOrigin => {
+    startDocumentHeightReporting({ parentOrigin });
+    overlay = new EmbeddedPreviewOverlay({ parentOrigin });
+  });
 
   window.addEventListener('message', event => {
     if (!isAllowedParentOrigin(event.origin)) return;
     if (event.source !== window.parent) return;
 
     if (isTypedMessage(event.data, ackMessageType)) {
-      startHeightReporting(event.origin);
+      connect(event.origin);
       return;
     }
 
+    if (overlay) overlay.handleMessage(event.data);
     handleMessage(event);
   });
 

--- a/src/toolbar/embedded-preview/overlay.css
+++ b/src/toolbar/embedded-preview/overlay.css
@@ -1,0 +1,98 @@
+:host {
+  --prismic-overlay-pin-size: 32px;
+  --prismic-overlay-ui-scale: 1;
+
+  display: block;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  pointer-events: none;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.placement-layer {
+  position: fixed;
+  inset: 0;
+}
+
+.surface,
+.pins {
+  pointer-events: none;
+}
+
+.surface {
+  position: relative;
+  width: 0;
+  height: 0;
+}
+
+.pins {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+}
+
+.placement-layer {
+  z-index: 1;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  cursor: none;
+  pointer-events: auto;
+}
+
+.pin {
+  position: absolute;
+  z-index: 2;
+  display: grid;
+  width: var(--prismic-overlay-pin-size);
+  height: var(--prismic-overlay-pin-size);
+  margin: 0;
+  padding: 4px;
+  place-items: center;
+  overflow: hidden;
+  color: #666;
+  background: white;
+  border: 0;
+  border-radius: 2px 50% 50%;
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 4%), 0 2px 6px rgb(0 0 0 / 8%), 0 8px 26px rgb(0 0 0 / 12%);
+  cursor: pointer;
+  pointer-events: auto;
+  transform: scale(var(--prismic-overlay-ui-scale));
+  transform-origin: top left;
+}
+
+.pin-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  color: #666;
+  background: #eee;
+  border-radius: 50%;
+}
+
+.pin-avatar-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.pin-avatar-fallback {
+  font-size: 8px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.cursor-pin {
+  position: fixed;
+  z-index: 3;
+  pointer-events: none;
+}

--- a/src/toolbar/embedded-preview/overlay.css
+++ b/src/toolbar/embedded-preview/overlay.css
@@ -66,6 +66,10 @@
   transform-origin: top left;
 }
 
+.pin[data-resolved="true"]:not([data-selected="true"]) {
+  opacity: 0.4;
+}
+
 .pin-avatar {
   display: flex;
   align-items: center;

--- a/src/toolbar/embedded-preview/overlay.js
+++ b/src/toolbar/embedded-preview/overlay.js
@@ -1,0 +1,499 @@
+import {
+  appendCSS,
+  readyDOM,
+  shadow,
+} from '@common';
+import overlayStyles from './overlay.css';
+
+const setOverlayMessageType = 'prismic:embedded-preview:set-overlay';
+const scrollToPinMessageType = 'prismic:embedded-preview:scroll-to-pin';
+
+const placeCommentMessageType = 'prismic:embedded-preview:place-comment';
+const pinClickedMessageType = 'prismic:embedded-preview:pin-clicked';
+const selectedPinPositionMessageType = 'prismic:embedded-preview:selected-pin-position';
+const dismissCommentMessageType = 'prismic:embedded-preview:dismiss-comment';
+
+const boundaryPadding = 4;
+
+export class EmbeddedPreviewOverlay {
+  constructor({ parentOrigin }) {
+    this.parentOrigin = parentOrigin;
+    this.state = emptyState();
+    this.lastPositionMessage = undefined;
+    this.scrollToThreadId = undefined;
+    this.root = undefined;
+    this.host = undefined;
+    this.surface = undefined;
+    this.pins = undefined;
+    this.cursorPin = undefined;
+
+    this.positionReportFrame = undefined;
+    this.reportSelectedPinPositionSoon = () => {
+      if (this.positionReportFrame !== undefined) return;
+
+      this.positionReportFrame = window.requestAnimationFrame(() => {
+        this.positionReportFrame = undefined;
+        this.reportSelectedPinPosition();
+      });
+    };
+    // Pins are document-positioned and move with native scrolling. Scrolling only
+    // needs to keep the Editor-hosted comment bubble anchored to the selected pin.
+    this.handleScroll = () => {
+      this.reportSelectedPinPositionSoon();
+    };
+    this.handleResize = () => {
+      this.renderPinPositions();
+      this.reportSelectedPinPositionSoon();
+    };
+
+    this.setup();
+  }
+
+  handleMessage(data) {
+    if (isOverlayMessage(data)) {
+      const nextState = normalizeOverlayState(data);
+      const selectedPinChanged = selectedPinKey(this.state) !== selectedPinKey(nextState);
+      this.state = nextState;
+      if (selectedPinChanged) {
+        this.lastPositionMessage = undefined;
+      }
+      this.render();
+      return;
+    }
+
+    if (isScrollToPinMessage(data)) {
+      this.scrollToThreadId = data.threadId;
+      this.scrollSelectedPinIntoView();
+    }
+  }
+
+  async setup() {
+    await readyDOM();
+
+    // Use a zero-sized document anchor so pins scroll natively without adding a
+    // full-document overlay element that could affect the website's layout.
+    this.root = shadow({
+      id: 'prismic-embedded-preview-overlay',
+      style: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: 0,
+        height: 0,
+        zIndex: 2147483646,
+        pointerEvents: 'none',
+      },
+    });
+    this.host = this.root.host || this.root;
+    appendCSS(this.root, overlayStyles);
+
+    this.surface = document.createElement('div');
+    this.surface.className = 'surface';
+    this.pins = document.createElement('div');
+    this.pins.className = 'pins';
+    this.surface.appendChild(this.pins);
+    this.root.appendChild(this.surface);
+
+    this.handleDocumentClick = this.handleDocumentClick.bind(this);
+    document.addEventListener('click', this.handleDocumentClick);
+    window.addEventListener('scroll', this.handleScroll, true);
+    window.addEventListener('resize', this.handleResize);
+
+    this.resizeObserver = new ResizeObserver(() => {
+      this.renderPinPositions();
+      this.reportSelectedPinPositionSoon();
+    });
+    this.resizeObserver.observe(document.documentElement);
+    this.resizeObserver.observe(document.body);
+
+    this.render();
+  }
+
+  render() {
+    if (!this.surface || !this.pins) return;
+
+    this.renderPlacementLayer();
+    this.renderPins();
+    this.renderCursorPinScale();
+    this.scrollSelectedPinIntoView();
+    this.reportSelectedPinPositionSoon();
+  }
+
+  renderPlacementLayer() {
+    const existingLayer = this.surface.querySelector('.placement-layer');
+
+    if (!this.state.placementEnabled) {
+      if (existingLayer) existingLayer.remove();
+      this.removeCursorPin();
+      return;
+    }
+
+    if (existingLayer) return;
+
+    const layer = document.createElement('button');
+    layer.type = 'button';
+    layer.className = 'placement-layer';
+    layer.setAttribute('aria-label', 'Place a comment here');
+    layer.addEventListener('click', event => this.placeComment(event));
+    layer.addEventListener('mousemove', event => this.renderCursorPin(event));
+    layer.addEventListener('mouseenter', event => this.renderCursorPin(event));
+    layer.addEventListener('mouseleave', () => this.removeCursorPin());
+    this.surface.insertBefore(layer, this.pins);
+  }
+
+  renderPins() {
+    this.pins.textContent = '';
+
+    this.state.pins.forEach(pin => {
+      this.pins.appendChild(this.createPin({
+        ...pin,
+        selected: pin.threadId === this.state.selectedThreadId,
+        type: 'thread',
+      }));
+    });
+
+    if (this.state.draftPin) {
+      this.pins.appendChild(this.createPin({
+        ...this.state.draftPin,
+        selected: true,
+        type: 'draft',
+      }));
+    }
+  }
+
+  renderPinPositions() {
+    if (!this.pins) return;
+
+    this.pins.querySelectorAll('.pin').forEach(pin => {
+      positionPin(pin, {
+        xRatio: Number(pin.dataset.xRatio),
+        yRatio: Number(pin.dataset.yRatio),
+      }, this.state.uiScale, this.host);
+    });
+  }
+
+  createPin(pin) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'pin';
+    button.dataset.pinType = pin.type;
+    button.dataset.selected = String(pin.selected);
+    button.dataset.xRatio = String(pin.xRatio);
+    button.dataset.yRatio = String(pin.yRatio);
+    button.setAttribute(
+      'aria-label',
+      pin.type === 'thread' ? `Open comment by ${pin.author.name || 'author'}` : 'New comment',
+    );
+
+    if (pin.type === 'thread') {
+      button.dataset.threadId = pin.threadId;
+      button.addEventListener('click', event => {
+        event.stopPropagation();
+        this.post({ type: pinClickedMessageType, threadId: pin.threadId });
+      });
+    } else {
+      button.disabled = true;
+    }
+
+    button.appendChild(createPinContent(pin.author));
+    setPinScale(button, this.state.uiScale);
+    positionPin(button, pin, this.state.uiScale, this.host);
+    return button;
+  }
+
+  placeComment(event) {
+    event.stopPropagation();
+
+    const { width, height } = measureDocument();
+    if (width === 0 || height === 0) return;
+
+    this.post({
+      type: placeCommentMessageType,
+      xRatio: clamp(event.pageX / width),
+      yRatio: clamp(event.pageY / height),
+    });
+  }
+
+  renderCursorPin(event) {
+    if (!this.state.placementAuthor || !this.root) return;
+
+    if (!this.cursorPin) {
+      this.cursorPin = this.createPin({
+        xRatio: 0,
+        yRatio: 0,
+        author: this.state.placementAuthor,
+        selected: false,
+        type: 'draft',
+      });
+      this.cursorPin.classList.add('cursor-pin');
+      this.root.appendChild(this.cursorPin);
+    }
+
+    this.cursorPin.style.left = `${event.clientX}px`;
+    this.cursorPin.style.top = `${event.clientY}px`;
+  }
+
+  renderCursorPinScale() {
+    if (!this.cursorPin) return;
+    setPinScale(this.cursorPin, this.state.uiScale);
+  }
+
+  removeCursorPin() {
+    if (!this.cursorPin) return;
+    this.cursorPin.remove();
+    this.cursorPin = undefined;
+  }
+
+  handleDocumentClick() {
+    if (this.state.placementEnabled) return;
+    if (!this.state.selectedThreadId && !this.state.draftPin) return;
+
+    this.post({ type: dismissCommentMessageType });
+  }
+
+  scrollSelectedPinIntoView() {
+    if (!this.pins || !this.scrollToThreadId) return;
+
+    const pinState = this.state.pins.find(
+      candidate => candidate.threadId === this.scrollToThreadId,
+    );
+    const pin = Array.from(this.pins.querySelectorAll('.pin')).find(
+      candidate => candidate.dataset.threadId === this.scrollToThreadId,
+    );
+    if (!pin || !pinState) return;
+
+    this.scrollToThreadId = undefined;
+    if (isFullyVisible(pin)) {
+      this.reportSelectedPinPositionSoon();
+      return;
+    }
+
+    const { width, height } = measureDocument();
+    window.scrollTo({
+      top: Math.max(0, pinState.yRatio * height - window.innerHeight / 2),
+      left: Math.max(0, pinState.xRatio * width - window.innerWidth / 2),
+      behavior: 'smooth',
+    });
+  }
+
+  reportSelectedPinPosition() {
+    const pin = this.getSelectedPin();
+    if (!pin) return;
+
+    const rect = pin.getBoundingClientRect();
+    const visible = isVisible(pin);
+
+    const message = {
+      type: selectedPinPositionMessageType,
+      pin: pin.dataset.pinType === 'thread'
+        ? { type: 'thread', threadId: pin.dataset.threadId }
+        : { type: 'draft' },
+      xRatio: rect.left / window.innerWidth,
+      yRatio: rect.top / window.innerHeight,
+      widthRatio: rect.width / window.innerWidth,
+      heightRatio: rect.height / window.innerHeight,
+      visible,
+    };
+    const serializedMessage = JSON.stringify(message);
+    if (serializedMessage === this.lastPositionMessage) return;
+
+    this.lastPositionMessage = serializedMessage;
+    this.post(message);
+  }
+
+  getSelectedPin() {
+    if (!this.pins) return undefined;
+
+    if (this.state.draftPin) {
+      return this.pins.querySelector('[data-pin-type="draft"]');
+    }
+
+    if (!this.state.selectedThreadId) return undefined;
+    return Array.from(this.pins.querySelectorAll('[data-pin-type="thread"]')).find(
+      pin => pin.dataset.threadId === this.state.selectedThreadId,
+    );
+  }
+
+  post(message) {
+    window.parent.postMessage(message, this.parentOrigin);
+  }
+}
+
+function emptyState() {
+  return {
+    placementEnabled: false,
+    uiScale: 1,
+    pins: [],
+    placementAuthor: undefined,
+    selectedThreadId: undefined,
+    draftPin: undefined,
+  };
+}
+
+function normalizeOverlayState(data) {
+  return {
+    placementEnabled: data.placementEnabled,
+    uiScale: data.uiScale,
+    pins: data.pins,
+    placementAuthor: data.placementAuthor,
+    selectedThreadId: data.selectedThreadId,
+    draftPin: data.draftPin,
+  };
+}
+
+function selectedPinKey(state) {
+  if (state.draftPin) return 'draft';
+  return state.selectedThreadId;
+}
+
+function isOverlayMessage(data) {
+  return isObject(data)
+    && data.type === setOverlayMessageType
+    && typeof data.placementEnabled === 'boolean'
+    && isPositiveNumber(data.uiScale)
+    && Array.isArray(data.pins)
+    && data.pins.every(isThreadPin)
+    && isOptionalAuthor(data.placementAuthor)
+    && isOptionalString(data.selectedThreadId)
+    && (data.draftPin === undefined || isPositionedAuthor(data.draftPin));
+}
+
+function isScrollToPinMessage(data) {
+  return isObject(data)
+    && data.type === scrollToPinMessageType
+    && typeof data.threadId === 'string'
+    && data.threadId.length > 0;
+}
+
+function isThreadPin(pin) {
+  return isPositionedAuthor(pin)
+    && typeof pin.threadId === 'string'
+    && pin.threadId.length > 0;
+}
+
+function isPositionedAuthor(value) {
+  return isObject(value)
+    && isRatio(value.xRatio)
+    && isRatio(value.yRatio)
+    && isAuthor(value.author);
+}
+
+function isOptionalAuthor(author) {
+  return author === undefined || isAuthor(author);
+}
+
+function isAuthor(author) {
+  return isObject(author)
+    && typeof author.id === 'string'
+    && isOptionalString(author.name)
+    && isOptionalString(author.avatarUrl);
+}
+
+function isOptionalString(value) {
+  return value === undefined || typeof value === 'string';
+}
+
+function isObject(value) {
+  return Boolean(value) && typeof value === 'object';
+}
+
+function isRatio(value) {
+  return typeof value === 'number' && value >= 0 && value <= 1;
+}
+
+function isPositiveNumber(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function createPinContent(author) {
+  const avatar = document.createElement('span');
+  avatar.className = 'pin-avatar';
+
+  if (author.avatarUrl) {
+    const image = document.createElement('img');
+    image.className = 'pin-avatar-image';
+    image.src = author.avatarUrl;
+    image.alt = '';
+    image.addEventListener('error', () => {
+      image.remove();
+      avatar.appendChild(createAvatarFallback(author));
+    }, { once: true });
+    avatar.appendChild(image);
+  } else {
+    avatar.appendChild(createAvatarFallback(author));
+  }
+
+  return avatar;
+}
+
+function createAvatarFallback(author) {
+  const fallback = document.createElement('span');
+  fallback.className = 'pin-avatar-fallback';
+  fallback.textContent = getInitials(author.name || author.id);
+  return fallback;
+}
+
+function getInitials(name) {
+  const parts = name.trim().split(/\s+/);
+  return [parts[0], parts[parts.length - 1]]
+    .filter((part, index) => part && (index === 0 || parts.length > 1))
+    .map(part => part.charAt(0).toLocaleUpperCase())
+    .join('');
+}
+
+function setPinScale(pin, uiScale) {
+  pin.style.setProperty('--prismic-overlay-ui-scale', String(uiScale));
+}
+
+function positionPin(pin, position, uiScale, host) {
+  const { width, height } = measureDocument();
+  const hostRect = host.getBoundingClientRect();
+  const hostDocumentLeft = hostRect.left + window.scrollX;
+  const hostDocumentTop = hostRect.top + window.scrollY;
+  const renderedPinSize = pinSize() * uiScale;
+  const maxLeft = Math.max(boundaryPadding, width - renderedPinSize - boundaryPadding);
+  const maxTop = Math.max(boundaryPadding, height - renderedPinSize - boundaryPadding);
+  const documentLeft = clamp(position.xRatio * width, boundaryPadding, maxLeft);
+  const documentTop = clamp(position.yRatio * height, boundaryPadding, maxTop);
+  pin.style.left = `${documentLeft - hostDocumentLeft}px`;
+  pin.style.top = `${documentTop - hostDocumentTop}px`;
+}
+
+function pinSize() {
+  return 32;
+}
+
+function measureDocument() {
+  return {
+    width: Math.max(
+      document.documentElement.clientWidth,
+      document.documentElement.scrollWidth,
+      document.body.scrollWidth,
+    ),
+    height: Math.max(
+      document.documentElement.clientHeight,
+      document.documentElement.scrollHeight,
+      document.body.scrollHeight,
+    ),
+  };
+}
+
+function isFullyVisible(element) {
+  const rect = element.getBoundingClientRect();
+  return rect.top >= 0
+    && rect.left >= 0
+    && rect.bottom <= window.innerHeight
+    && rect.right <= window.innerWidth;
+}
+
+function isVisible(element) {
+  const rect = element.getBoundingClientRect();
+  return rect.bottom > 0
+    && rect.right > 0
+    && rect.top < window.innerHeight
+    && rect.left < window.innerWidth;
+}
+
+function clamp(value, min = 0, max = 1) {
+  return Math.min(Math.max(value, min), max);
+}

--- a/src/toolbar/embedded-preview/overlay.js
+++ b/src/toolbar/embedded-preview/overlay.js
@@ -200,10 +200,18 @@ export class EmbeddedPreviewOverlay {
       button.dataset.threadId = pin.threadId;
       button.addEventListener('click', event => {
         event.stopPropagation();
-        this.post({
-          type: pin.selected ? deselectPinMessageType : selectPinMessageType,
-          pin: { type: 'thread', threadId: pin.threadId },
-        });
+        if (pin.selected) {
+          this.post({
+            type: deselectPinMessageType,
+            pin: { type: 'thread', threadId: pin.threadId },
+          });
+        } else {
+          this.post({
+            type: selectPinMessageType,
+            pin: { type: 'thread', threadId: pin.threadId },
+            rect: getPinRect(button),
+          });
+        }
       });
     } else {
       button.disabled = true;
@@ -228,10 +236,15 @@ export class EmbeddedPreviewOverlay {
     const { width, height } = measureDocument();
     if (width === 0 || height === 0) return;
 
-    this.post({
-      type: placeCommentMessageType,
+    const position = {
       xRatio: clamp(event.pageX / width),
       yRatio: clamp(event.pageY / height),
+    };
+
+    this.post({
+      type: placeCommentMessageType,
+      ...position,
+      rect: getPinRectFromPosition(position, this.uiScale),
     });
   }
 
@@ -309,19 +322,13 @@ export class EmbeddedPreviewOverlay {
     const pin = this.getSelectedPin();
     if (!pin) return;
 
-    const rect = pin.getBoundingClientRect();
-    const visible = isVisible(pin);
-
     const message = {
       type: reportSelectedPinPositionMessageType,
       pin: pin.dataset.pinType === 'thread'
         ? { type: 'thread', threadId: pin.dataset.threadId }
         : { type: 'draft' },
-      xRatio: rect.left / window.innerWidth,
-      yRatio: rect.top / window.innerHeight,
-      widthRatio: rect.width / window.innerWidth,
-      heightRatio: rect.height / window.innerHeight,
-      visible,
+      rect: getPinRect(pin),
+      visible: isVisible(pin),
     };
     const serializedMessage = JSON.stringify(message);
     if (serializedMessage === this.lastPositionMessage) return;
@@ -487,17 +494,38 @@ function getInitials(name) {
 }
 
 function positionPin(pin, position, uiScale, host) {
-  const { width, height } = measureDocument();
+  const { left, top } = getPinDocumentPosition(position, uiScale);
   const hostRect = host.getBoundingClientRect();
   const hostDocumentLeft = hostRect.left + window.scrollX;
   const hostDocumentTop = hostRect.top + window.scrollY;
+  pin.style.left = `${left - hostDocumentLeft}px`;
+  pin.style.top = `${top - hostDocumentTop}px`;
+}
+
+function getPinDocumentPosition(position, uiScale) {
+  const { width, height } = measureDocument();
   const renderedPinSize = pinSize() * uiScale;
   const maxLeft = Math.max(boundaryPadding, width - renderedPinSize - boundaryPadding);
   const maxTop = Math.max(boundaryPadding, height - renderedPinSize - boundaryPadding);
-  const documentLeft = clamp(position.xRatio * width, boundaryPadding, maxLeft);
-  const documentTop = clamp(position.yRatio * height, boundaryPadding, maxTop);
-  pin.style.left = `${documentLeft - hostDocumentLeft}px`;
-  pin.style.top = `${documentTop - hostDocumentTop}px`;
+
+  return {
+    left: clamp(position.xRatio * width, boundaryPadding, maxLeft),
+    top: clamp(position.yRatio * height, boundaryPadding, maxTop),
+  };
+}
+
+// Lets a pin be measured before it is rendered, so placing a comment can report
+// the draft pin's rectangle without waiting for a round trip through the Editor.
+function getPinRectFromPosition(position, uiScale) {
+  const { left, top } = getPinDocumentPosition(position, uiScale);
+  const renderedPinSize = pinSize() * uiScale;
+
+  return toPinRect({
+    left: left - window.scrollX,
+    top: top - window.scrollY,
+    width: renderedPinSize,
+    height: renderedPinSize,
+  });
 }
 
 function pinSize() {
@@ -533,6 +561,19 @@ function isVisible(element) {
     && rect.right > 0
     && rect.top < window.innerHeight
     && rect.left < window.innerWidth;
+}
+
+function getPinRect(element) {
+  return toPinRect(element.getBoundingClientRect());
+}
+
+function toPinRect(rect) {
+  return {
+    xRatio: rect.left / window.innerWidth,
+    yRatio: rect.top / window.innerHeight,
+    widthRatio: rect.width / window.innerWidth,
+    heightRatio: rect.height / window.innerHeight,
+  };
 }
 
 function clamp(value, min = 0, max = 1) {

--- a/src/toolbar/embedded-preview/overlay.js
+++ b/src/toolbar/embedded-preview/overlay.js
@@ -162,9 +162,10 @@ export class EmbeddedPreviewOverlay {
       }));
     });
 
-    if (this.commentState.draftPin) {
+    if (this.commentState.draftPin && this.commentState.draftAuthor) {
       this.pins.appendChild(this.createPin({
         ...this.commentState.draftPin,
+        author: this.commentState.draftAuthor,
         selected: true,
         type: 'draft',
       }));
@@ -235,13 +236,13 @@ export class EmbeddedPreviewOverlay {
   }
 
   renderCursorPin(event) {
-    if (!this.commentState.placementAuthor || !this.root) return;
+    if (!this.commentState.draftAuthor || !this.root) return;
 
     if (!this.cursorPin) {
       this.cursorPin = this.createPin({
         xRatio: 0,
         yRatio: 0,
-        author: this.commentState.placementAuthor,
+        author: this.commentState.draftAuthor,
         selected: false,
         type: 'draft',
       });
@@ -351,7 +352,7 @@ function emptyCommentOverlayState() {
   return {
     placementEnabled: false,
     pins: [],
-    placementAuthor: undefined,
+    draftAuthor: undefined,
     selectedThreadId: undefined,
     draftPin: undefined,
   };
@@ -361,7 +362,7 @@ function normalizeCommentOverlayState(data) {
   return {
     placementEnabled: data.placementEnabled,
     pins: data.pins,
-    placementAuthor: data.placementAuthor,
+    draftAuthor: data.draftAuthor,
     selectedThreadId: data.selectedThreadId,
     draftPin: data.draftPin,
   };
@@ -390,9 +391,12 @@ function isCommentOverlayMessage(data) {
     && typeof data.placementEnabled === 'boolean'
     && Array.isArray(data.pins)
     && data.pins.every(isThreadPin)
-    && isOptionalAuthor(data.placementAuthor)
+    && isOptionalAuthor(data.draftAuthor)
     && isOptionalString(data.selectedThreadId)
-    && (data.draftPin === undefined || isPositionedAuthor(data.draftPin));
+    && (
+      data.draftPin === undefined
+      || (isPositioned(data.draftPin) && isAuthor(data.draftAuthor))
+    );
 }
 
 function isScrollToPinMessage(data) {
@@ -409,10 +413,14 @@ function isThreadPin(pin) {
 }
 
 function isPositionedAuthor(value) {
+  return isPositioned(value)
+    && isAuthor(value.author);
+}
+
+function isPositioned(value) {
   return isObject(value)
     && isRatio(value.xRatio)
-    && isRatio(value.yRatio)
-    && isAuthor(value.author);
+    && isRatio(value.yRatio);
 }
 
 function isOptionalAuthor(author) {

--- a/src/toolbar/embedded-preview/overlay.js
+++ b/src/toolbar/embedded-preview/overlay.js
@@ -5,7 +5,8 @@ import {
 } from '@common';
 import overlayStyles from './overlay.css';
 
-const setOverlayMessageType = 'prismic:embedded-preview:set-overlay';
+const setOverlayScaleMessageType = 'prismic:embedded-preview:set-overlay-scale';
+const setCommentOverlayMessageType = 'prismic:embedded-preview:set-comment-overlay';
 const scrollToPinMessageType = 'prismic:embedded-preview:scroll-to-pin';
 
 const placeCommentMessageType = 'prismic:embedded-preview:place-comment';
@@ -18,7 +19,8 @@ const boundaryPadding = 4;
 export class EmbeddedPreviewOverlay {
   constructor({ parentOrigin }) {
     this.parentOrigin = parentOrigin;
-    this.state = emptyState();
+    this.uiScale = 1;
+    this.commentState = emptyCommentOverlayState();
     this.lastPositionMessage = undefined;
     this.scrollToThreadId = undefined;
     this.root = undefined;
@@ -50,10 +52,18 @@ export class EmbeddedPreviewOverlay {
   }
 
   handleMessage(data) {
-    if (isOverlayMessage(data)) {
-      const nextState = normalizeOverlayState(data);
-      const selectedPinChanged = selectedPinKey(this.state) !== selectedPinKey(nextState);
-      this.state = nextState;
+    if (isOverlayScaleMessage(data)) {
+      if (this.uiScale === data.uiScale) return;
+      this.uiScale = data.uiScale;
+      this.applyOverlayScale();
+      return;
+    }
+
+    if (isCommentOverlayMessage(data)) {
+      const nextState = normalizeCommentOverlayState(data);
+      const previousSelectedPin = selectedPinKey(this.commentState);
+      const selectedPinChanged = previousSelectedPin !== selectedPinKey(nextState);
+      this.commentState = nextState;
       if (selectedPinChanged) {
         this.lastPositionMessage = undefined;
       }
@@ -85,6 +95,7 @@ export class EmbeddedPreviewOverlay {
       },
     });
     this.host = this.root.host || this.root;
+    this.applyOverlayScale();
     appendCSS(this.root, overlayStyles);
 
     this.surface = document.createElement('div');
@@ -114,7 +125,6 @@ export class EmbeddedPreviewOverlay {
 
     this.renderPlacementLayer();
     this.renderPins();
-    this.renderCursorPinScale();
     this.scrollSelectedPinIntoView();
     this.reportSelectedPinPositionSoon();
   }
@@ -122,7 +132,7 @@ export class EmbeddedPreviewOverlay {
   renderPlacementLayer() {
     const existingLayer = this.surface.querySelector('.placement-layer');
 
-    if (!this.state.placementEnabled) {
+    if (!this.commentState.placementEnabled) {
       if (existingLayer) existingLayer.remove();
       this.removeCursorPin();
       return;
@@ -144,17 +154,17 @@ export class EmbeddedPreviewOverlay {
   renderPins() {
     this.pins.textContent = '';
 
-    this.state.pins.forEach(pin => {
+    this.commentState.pins.forEach(pin => {
       this.pins.appendChild(this.createPin({
         ...pin,
-        selected: pin.threadId === this.state.selectedThreadId,
+        selected: pin.threadId === this.commentState.selectedThreadId,
         type: 'thread',
       }));
     });
 
-    if (this.state.draftPin) {
+    if (this.commentState.draftPin) {
       this.pins.appendChild(this.createPin({
-        ...this.state.draftPin,
+        ...this.commentState.draftPin,
         selected: true,
         type: 'draft',
       }));
@@ -168,7 +178,7 @@ export class EmbeddedPreviewOverlay {
       positionPin(pin, {
         xRatio: Number(pin.dataset.xRatio),
         yRatio: Number(pin.dataset.yRatio),
-      }, this.state.uiScale, this.host);
+      }, this.uiScale, this.host);
     });
   }
 
@@ -199,15 +209,14 @@ export class EmbeddedPreviewOverlay {
     }
 
     button.appendChild(createPinContent(pin.author));
-    setPinScale(button, this.state.uiScale);
-    positionPin(button, pin, this.state.uiScale, this.host);
+    positionPin(button, pin, this.uiScale, this.host);
     return button;
   }
 
   placeComment(event) {
     event.stopPropagation();
 
-    if (this.state.draftPin) {
+    if (this.commentState.draftPin) {
       this.post({
         type: deselectPinMessageType,
         pin: { type: 'draft' },
@@ -226,13 +235,13 @@ export class EmbeddedPreviewOverlay {
   }
 
   renderCursorPin(event) {
-    if (!this.state.placementAuthor || !this.root) return;
+    if (!this.commentState.placementAuthor || !this.root) return;
 
     if (!this.cursorPin) {
       this.cursorPin = this.createPin({
         xRatio: 0,
         yRatio: 0,
-        author: this.state.placementAuthor,
+        author: this.commentState.placementAuthor,
         selected: false,
         type: 'draft',
       });
@@ -244,21 +253,27 @@ export class EmbeddedPreviewOverlay {
     this.cursorPin.style.top = `${event.clientY}px`;
   }
 
-  renderCursorPinScale() {
-    if (!this.cursorPin) return;
-    setPinScale(this.cursorPin, this.state.uiScale);
-  }
-
   removeCursorPin() {
     if (!this.cursorPin) return;
     this.cursorPin.remove();
     this.cursorPin = undefined;
   }
 
-  handleDocumentClick() {
-    if (this.state.placementEnabled) return;
+  applyOverlayScale() {
+    if (!this.host) return;
 
-    const pin = selectedPinIdentity(this.state);
+    this.host.style.setProperty(
+      '--prismic-overlay-ui-scale',
+      String(this.uiScale),
+    );
+    this.renderPinPositions();
+    this.reportSelectedPinPositionSoon();
+  }
+
+  handleDocumentClick() {
+    if (this.commentState.placementEnabled) return;
+
+    const pin = selectedPinIdentity(this.commentState);
     if (!pin) return;
 
     this.post({ type: deselectPinMessageType, pin });
@@ -267,7 +282,7 @@ export class EmbeddedPreviewOverlay {
   scrollSelectedPinIntoView() {
     if (!this.pins || !this.scrollToThreadId) return;
 
-    const pinState = this.state.pins.find(
+    const pinState = this.commentState.pins.find(
       candidate => candidate.threadId === this.scrollToThreadId,
     );
     const pin = Array.from(this.pins.querySelectorAll('.pin')).find(
@@ -317,13 +332,13 @@ export class EmbeddedPreviewOverlay {
   getSelectedPin() {
     if (!this.pins) return undefined;
 
-    if (this.state.draftPin) {
+    if (this.commentState.draftPin) {
       return this.pins.querySelector('[data-pin-type="draft"]');
     }
 
-    if (!this.state.selectedThreadId) return undefined;
+    if (!this.commentState.selectedThreadId) return undefined;
     return Array.from(this.pins.querySelectorAll('[data-pin-type="thread"]')).find(
-      pin => pin.dataset.threadId === this.state.selectedThreadId,
+      pin => pin.dataset.threadId === this.commentState.selectedThreadId,
     );
   }
 
@@ -332,10 +347,9 @@ export class EmbeddedPreviewOverlay {
   }
 }
 
-function emptyState() {
+function emptyCommentOverlayState() {
   return {
     placementEnabled: false,
-    uiScale: 1,
     pins: [],
     placementAuthor: undefined,
     selectedThreadId: undefined,
@@ -343,10 +357,9 @@ function emptyState() {
   };
 }
 
-function normalizeOverlayState(data) {
+function normalizeCommentOverlayState(data) {
   return {
     placementEnabled: data.placementEnabled,
-    uiScale: data.uiScale,
     pins: data.pins,
     placementAuthor: data.placementAuthor,
     selectedThreadId: data.selectedThreadId,
@@ -365,11 +378,16 @@ function selectedPinIdentity(state) {
   return { type: 'thread', threadId: state.selectedThreadId };
 }
 
-function isOverlayMessage(data) {
+function isOverlayScaleMessage(data) {
   return isObject(data)
-    && data.type === setOverlayMessageType
+    && data.type === setOverlayScaleMessageType
+    && isPositiveNumber(data.uiScale);
+}
+
+function isCommentOverlayMessage(data) {
+  return isObject(data)
+    && data.type === setCommentOverlayMessageType
     && typeof data.placementEnabled === 'boolean'
-    && isPositiveNumber(data.uiScale)
     && Array.isArray(data.pins)
     && data.pins.every(isThreadPin)
     && isOptionalAuthor(data.placementAuthor)
@@ -458,10 +476,6 @@ function getInitials(name) {
     .filter((part, index) => part && (index === 0 || parts.length > 1))
     .map(part => part.charAt(0).toLocaleUpperCase())
     .join('');
-}
-
-function setPinScale(pin, uiScale) {
-  pin.style.setProperty('--prismic-overlay-ui-scale', String(uiScale));
 }
 
 function positionPin(pin, position, uiScale, host) {

--- a/src/toolbar/embedded-preview/overlay.js
+++ b/src/toolbar/embedded-preview/overlay.js
@@ -9,9 +9,9 @@ const setOverlayMessageType = 'prismic:embedded-preview:set-overlay';
 const scrollToPinMessageType = 'prismic:embedded-preview:scroll-to-pin';
 
 const placeCommentMessageType = 'prismic:embedded-preview:place-comment';
-const pinClickedMessageType = 'prismic:embedded-preview:pin-clicked';
-const selectedPinPositionMessageType = 'prismic:embedded-preview:selected-pin-position';
-const dismissCommentMessageType = 'prismic:embedded-preview:dismiss-comment';
+const selectPinMessageType = 'prismic:embedded-preview:select-pin';
+const deselectPinMessageType = 'prismic:embedded-preview:deselect-pin';
+const reportSelectedPinPositionMessageType = 'prismic:embedded-preview:report-selected-pin-position';
 
 const boundaryPadding = 4;
 
@@ -189,7 +189,10 @@ export class EmbeddedPreviewOverlay {
       button.dataset.threadId = pin.threadId;
       button.addEventListener('click', event => {
         event.stopPropagation();
-        this.post({ type: pinClickedMessageType, threadId: pin.threadId });
+        this.post({
+          type: pin.selected ? deselectPinMessageType : selectPinMessageType,
+          pin: { type: 'thread', threadId: pin.threadId },
+        });
       });
     } else {
       button.disabled = true;
@@ -203,6 +206,14 @@ export class EmbeddedPreviewOverlay {
 
   placeComment(event) {
     event.stopPropagation();
+
+    if (this.state.draftPin) {
+      this.post({
+        type: deselectPinMessageType,
+        pin: { type: 'draft' },
+      });
+      return;
+    }
 
     const { width, height } = measureDocument();
     if (width === 0 || height === 0) return;
@@ -246,9 +257,11 @@ export class EmbeddedPreviewOverlay {
 
   handleDocumentClick() {
     if (this.state.placementEnabled) return;
-    if (!this.state.selectedThreadId && !this.state.draftPin) return;
 
-    this.post({ type: dismissCommentMessageType });
+    const pin = selectedPinIdentity(this.state);
+    if (!pin) return;
+
+    this.post({ type: deselectPinMessageType, pin });
   }
 
   scrollSelectedPinIntoView() {
@@ -284,7 +297,7 @@ export class EmbeddedPreviewOverlay {
     const visible = isVisible(pin);
 
     const message = {
-      type: selectedPinPositionMessageType,
+      type: reportSelectedPinPositionMessageType,
       pin: pin.dataset.pinType === 'thread'
         ? { type: 'thread', threadId: pin.dataset.threadId }
         : { type: 'draft' },
@@ -344,6 +357,12 @@ function normalizeOverlayState(data) {
 function selectedPinKey(state) {
   if (state.draftPin) return 'draft';
   return state.selectedThreadId;
+}
+
+function selectedPinIdentity(state) {
+  if (state.draftPin) return { type: 'draft' };
+  if (!state.selectedThreadId) return;
+  return { type: 'thread', threadId: state.selectedThreadId };
 }
 
 function isOverlayMessage(data) {

--- a/src/toolbar/embedded-preview/overlay.js
+++ b/src/toolbar/embedded-preview/overlay.js
@@ -200,7 +200,10 @@ export class EmbeddedPreviewOverlay {
       button.dataset.threadId = pin.threadId;
       button.addEventListener('click', event => {
         event.stopPropagation();
-        if (pin.selected) {
+        const selected = button.dataset.selected === 'true';
+        button.dataset.selected = String(!selected);
+
+        if (selected) {
           this.post({
             type: deselectPinMessageType,
             pin: { type: 'thread', threadId: pin.threadId },

--- a/src/toolbar/embedded-preview/overlay.js
+++ b/src/toolbar/embedded-preview/overlay.js
@@ -189,6 +189,7 @@ export class EmbeddedPreviewOverlay {
     button.className = 'pin';
     button.dataset.pinType = pin.type;
     button.dataset.selected = String(pin.selected);
+    button.dataset.resolved = String(Boolean(pin.resolved));
     button.dataset.xRatio = String(pin.xRatio);
     button.dataset.yRatio = String(pin.yRatio);
     button.setAttribute(
@@ -419,7 +420,8 @@ function isScrollToPinMessage(data) {
 function isThreadPin(pin) {
   return isPositionedAuthor(pin)
     && typeof pin.threadId === 'string'
-    && pin.threadId.length > 0;
+    && pin.threadId.length > 0
+    && typeof pin.resolved === 'boolean';
 }
 
 function isPositionedAuthor(value) {


### PR DESCRIPTION
## Context

Some customer websites cannot be measured reliably from Editor. Live-preview comment pins were previously rendered by Editor over a scaled iframe, which required Editor to reproduce the website’s document geometry. This could cause incorrect positioning, delayed scrolling updates, and height-measurement feedback loops that prevented affected customers from using preview comments reliably.

This PR is a tactical change intended to unblock those customers now. Prismic Toolbar runs inside the preview website, where it can render pins using the website’s own document and scrolling context.

- [RFC: Move live preview overlays into Prismic Toolbar](https://app.notion.com/p/prismic/RFC-Move-live-preview-overlays-into-Prismic-Toolbar-3c93bee08669816ca8dfe9c4c6026317?source=copy_link)
- [Related Slack discussion](https://prismic-team.slack.com/archives/C0BFJ1YF61J/p1785430535506329?thread_ts=1785430535.506329&cid=C0BFJ1YF61J)
- [Companion Editor PR](https://github.com/prismicio/editor/pull/2469)

## What this does

Prismic Toolbar now renders live-preview comment pins inside the preview website while Editor remains the source of truth for comments, drafts, and selection.

For users, this means:

- unresolved comment threads and new-comment drafts are displayed using author avatars
- pins remain synchronized with native website scrolling
- pin UI keeps its intended size when Editor scales the preview iframe
- comment bubbles open beside the complete pin rectangle
- selecting and deselecting pins does not depend on a state round trip
- selecting an offscreen comment in Editor scrolls the website to its pin
- placing a new comment immediately anchors the draft composer at the selected position

## How it works

The embedded-preview handshake initializes a Shadow DOM overlay inside the website.

Editor sends separate messages for:

- the overlay UI scale
- comment overlay state, including unresolved pins, draft state, placement mode, authors, and the selected thread
- explicit scroll-to-pin requests

Toolbar sends events for:

- placing a comment, including the initial draft-pin rectangle
- selecting a thread pin, including its initial rectangle
- deselecting a thread or draft pin
- reporting the selected pin’s updated rectangle and visibility during scrolling and resizing

Pins use document-absolute positioning, so they move with native scrolling without waiting for JavaScript repositioning. Toolbar counter-scales their UI to compensate for Editor’s iframe scale, while Editor keeps ownership of the Liveblocks comment bubble.

This implementation deliberately adds low-level JavaScript to the current Toolbar. We accept that short-term maintenance cost to unblock affected customers, but this is not the foundation we want to maintain in the long term. The planned Toolbar rewrite will let us implement this behavior more safely and clearly with TypeScript and Preact.
