### PR TITLE
fix(preview): keep live updates in sync across editor and site tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "webpack --mode development --watch",
     "build:prod": "webpack --mode production",
     "serve": "http-server -p 8081 -g -c-1 build/",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "node tests/preview.test.cjs"
   },
   "engines": {
     "node": ">=4.8.1",

--- a/src/common/cookie.js
+++ b/src/common/cookie.js
@@ -43,9 +43,20 @@ export function demolishCookie(name, options) {
 }
 
 function getSameSiteAttributes() {
-  if (window.self !== window.top && window.location.protocol === 'https:') {
+  if (window.self !== window.top && (window.location.protocol === 'https:' || isLoopbackHost())) {
     return { sameSite: 'none', secure: true };
   }
 
   return { sameSite: 'lax' };
+}
+
+function isLoopbackHost() {
+  const { hostname } = window.location;
+
+  return (
+    hostname === 'localhost'
+    || hostname === '::1'
+    || hostname === '[::1]'
+    || /^127(?:\.\d{1,3}){3}$/.test(hostname)
+  );
 }

--- a/src/toolbar/direct-preview-watch.js
+++ b/src/toolbar/direct-preview-watch.js
@@ -1,51 +1,108 @@
-import { getCookie, setCookie, toolbarEvents, dispatchToolbarEvent } from '@common';
+import { deleteCookie, getCookie, setCookie, toolbarEvents, dispatchToolbarEvent } from '@common';
+import { reloadOrigin } from './utils';
 
 export const DIRECT_PREVIEW_REF_UPDATE_MARKER_COOKIE = 'io.prismic.preview.updated';
-export const DIRECT_PREVIEW_REF_UPDATE_MARKER_VALUE = 'v1';
-export const DIRECT_PREVIEW_REF_UPDATE_MARKER_EXPIRES_DAYS = 1 / 24;
 export const DIRECT_PREVIEW_REF_WATCH_INTERVAL = 250;
 
 const previewCookieName = 'io.prismic.preview';
 
-export function markDirectPreviewRefUpdated() {
+export function markDirectPreviewRefUpdated({ repository, ref }) {
   setCookie(
     DIRECT_PREVIEW_REF_UPDATE_MARKER_COOKIE,
-    DIRECT_PREVIEW_REF_UPDATE_MARKER_VALUE,
-    DIRECT_PREVIEW_REF_UPDATE_MARKER_EXPIRES_DAYS
+    { version: 2, repository, ref },
+    // Session lifetime: an idle editor must not hand ownership to a stale legacy
+    // preview after an arbitrary timeout. A new ref or exit invalidates this marker.
+    null
   );
 }
 
+export function clearDirectPreviewRef() {
+  deleteCookie(DIRECT_PREVIEW_REF_UPDATE_MARKER_COOKIE);
+}
+
+// Parse only our protocol metadata; the preview ref itself remains opaque.
+export function getDirectPreviewState(readCookie = getCookie) {
+  const marker = readCookie(DIRECT_PREVIEW_REF_UPDATE_MARKER_COOKIE);
+  if (!marker) return;
+
+  try {
+    const state = JSON.parse(marker);
+    if (
+      state && state.version === 2
+      && typeof state.repository === 'string' && state.repository.length > 0
+      && typeof state.ref === 'string' && state.ref.length > 0
+      && state.ref === readCookie(previewCookieName)
+    ) return state;
+  } catch (error) {
+    // Old or stale markers do not claim a regular preview session.
+  }
+}
+
 export function createDirectPreviewRefWatcher({
+  repository,
   readCookie = getCookie,
   emitToolbarEvent = dispatchToolbarEvent,
+  reload = reloadOrigin,
 } = {}) {
-  let hasLastSeenRef = false;
-  let lastSeenRef;
-
-  if (readCookie(DIRECT_PREVIEW_REF_UPDATE_MARKER_COOKIE)) {
-    const startupRef = readCookie(previewCookieName);
-    if (startupRef) {
-      lastSeenRef = startupRef;
-      hasLastSeenRef = true;
-    }
-  }
+  const startupState = getDirectPreviewState(readCookie);
+  let lastSeenRef = startupState && startupState.repository === repository
+    ? startupState.ref
+    : undefined;
+  let isStartup = true;
 
   return function watchDirectPreviewRef() {
-    const marker = readCookie(DIRECT_PREVIEW_REF_UPDATE_MARKER_COOKIE);
-    const ref = readCookie(previewCookieName);
+    const state = getDirectPreviewState(readCookie);
+    const ref = state && state.repository === repository ? state.ref : undefined;
+    const reconcileStartup = isStartup && ref && ref === lastSeenRef;
+    isStartup = false;
 
-    if (!marker || !ref) return;
-    if (hasLastSeenRef && ref === lastSeenRef) return;
+    if (!ref) {
+      const ended = lastSeenRef && !readCookie(previewCookieName);
+      lastSeenRef = undefined;
+      if (ended) {
+        clearStartupReload(repository);
+        if (emitToolbarEvent(toolbarEvents.previewEnd)) reload();
+      }
+      return;
+    }
+    if (ref === lastSeenRef && !reconcileStartup) return;
 
     lastSeenRef = ref;
-    hasLastSeenRef = true;
-    emitToolbarEvent(toolbarEvents.previewUpdate, { ref });
+    // The toolbar can load after SSR and after the cookie changed. Reconcile
+    // once on startup; cookie equality cannot prove what the page rendered.
+    if (
+      emitToolbarEvent(toolbarEvents.previewUpdate, { ref })
+      && prepareReload({ repository, ref, reconcileStartup })
+    ) reload();
   };
 }
 
-export function setupDirectPreviewRefWatcher() {
+function prepareReload({ repository, ref, reconcileStartup }) {
+  try {
+    const key = `io.prismic.preview.reloaded.${repository}`;
+    const value = JSON.stringify([window.location.href, ref]);
+    if (reconcileStartup && window.sessionStorage.getItem(key) === value) return false;
+    // A generic site has no soft-update listener. Remember its startup reload
+    // in this tab so the next page load cannot enter a reload loop.
+    window.sessionStorage.setItem(key, value);
+    return true;
+  } catch (error) {
+    // Without storage only subsequent changes can safely hard reload.
+    return !reconcileStartup;
+  }
+}
+
+function clearStartupReload(repository) {
+  try {
+    window.sessionStorage.removeItem(`io.prismic.preview.reloaded.${repository}`);
+  } catch (error) {
+    // Session storage can be unavailable in restrictive browser settings.
+  }
+}
+
+export function setupDirectPreviewRefWatcher(options) {
   return window.setInterval(
-    createDirectPreviewRefWatcher(),
+    createDirectPreviewRefWatcher(options),
     DIRECT_PREVIEW_REF_WATCH_INTERVAL
   );
 }

--- a/src/toolbar/direct-preview-watch.js
+++ b/src/toolbar/direct-preview-watch.js
@@ -1,0 +1,51 @@
+import { getCookie, setCookie, toolbarEvents, dispatchToolbarEvent } from '@common';
+
+export const DIRECT_PREVIEW_REF_UPDATE_MARKER_COOKIE = 'io.prismic.preview.updated';
+export const DIRECT_PREVIEW_REF_UPDATE_MARKER_VALUE = 'v1';
+export const DIRECT_PREVIEW_REF_UPDATE_MARKER_EXPIRES_DAYS = 1 / 24;
+export const DIRECT_PREVIEW_REF_WATCH_INTERVAL = 250;
+
+const previewCookieName = 'io.prismic.preview';
+
+export function markDirectPreviewRefUpdated() {
+  setCookie(
+    DIRECT_PREVIEW_REF_UPDATE_MARKER_COOKIE,
+    DIRECT_PREVIEW_REF_UPDATE_MARKER_VALUE,
+    DIRECT_PREVIEW_REF_UPDATE_MARKER_EXPIRES_DAYS
+  );
+}
+
+export function createDirectPreviewRefWatcher({
+  readCookie = getCookie,
+  emitToolbarEvent = dispatchToolbarEvent,
+} = {}) {
+  let hasLastSeenRef = false;
+  let lastSeenRef;
+
+  if (readCookie(DIRECT_PREVIEW_REF_UPDATE_MARKER_COOKIE)) {
+    const startupRef = readCookie(previewCookieName);
+    if (startupRef) {
+      lastSeenRef = startupRef;
+      hasLastSeenRef = true;
+    }
+  }
+
+  return function watchDirectPreviewRef() {
+    const marker = readCookie(DIRECT_PREVIEW_REF_UPDATE_MARKER_COOKIE);
+    const ref = readCookie(previewCookieName);
+
+    if (!marker || !ref) return;
+    if (hasLastSeenRef && ref === lastSeenRef) return;
+
+    lastSeenRef = ref;
+    hasLastSeenRef = true;
+    emitToolbarEvent(toolbarEvents.previewUpdate, { ref });
+  };
+}
+
+export function setupDirectPreviewRefWatcher() {
+  return window.setInterval(
+    createDirectPreviewRefWatcher(),
+    DIRECT_PREVIEW_REF_WATCH_INTERVAL
+  );
+}

--- a/src/toolbar/embedded-preview/index.js
+++ b/src/toolbar/embedded-preview/index.js
@@ -1,5 +1,5 @@
 import { deleteCookie, getCookie, once, setCookie } from '@common';
-import { markDirectPreviewRefUpdated } from '../direct-preview-watch';
+import { clearDirectPreviewRef, markDirectPreviewRefUpdated } from '../direct-preview-watch';
 import { startDocumentHeightReporting } from './document-height';
 
 const pushMarkerWindowName = 'prismic:embedded-preview';
@@ -52,12 +52,20 @@ export class EmbeddedPreviewCookie {
   }
 }
 
-export function setupEmbeddedPreviewPush({ preview }) {
+export function setupEmbeddedPreviewPush({ preview, repository }) {
   connectToParent(event => {
     if (!isSetRefMessage(event.data)) return;
 
+    // Claim before writing the raw cookie: regular tabs must already see the
+    // matching metadata as soon as the new ref becomes visible. The marker
+    // only takes effect when its opaque ref matches the actual cookie.
+    if (event.data.reload === false) {
+      markDirectPreviewRefUpdated({ repository, ref: event.data.token });
+    } else {
+      clearDirectPreviewRef();
+    }
+
     preview.updateFromRef(event.data.token, event.data.reload)
-      .then(markDirectPreviewRefUpdated)
       .catch(error => {
         console.error('Failed to update embedded preview ref.', error);
       });

--- a/src/toolbar/embedded-preview/index.js
+++ b/src/toolbar/embedded-preview/index.js
@@ -55,7 +55,7 @@ export function setupEmbeddedPreviewPush({ preview }) {
   connectToParent(event => {
     if (!isSetRefMessage(event.data)) return;
 
-    preview.updateFromRef(event.data.token).catch(error => {
+    preview.updateFromRef(event.data.token, event.data.reload).catch(error => {
       console.error('Failed to update embedded preview ref.', error);
     });
   });

--- a/src/toolbar/embedded-preview/index.js
+++ b/src/toolbar/embedded-preview/index.js
@@ -1,4 +1,5 @@
 import { deleteCookie, getCookie, once, setCookie } from '@common';
+import { markDirectPreviewRefUpdated } from '../direct-preview-watch';
 import { startDocumentHeightReporting } from './document-height';
 
 const pushMarkerWindowName = 'prismic:embedded-preview';
@@ -55,9 +56,11 @@ export function setupEmbeddedPreviewPush({ preview }) {
   connectToParent(event => {
     if (!isSetRefMessage(event.data)) return;
 
-    preview.updateFromRef(event.data.token, event.data.reload).catch(error => {
-      console.error('Failed to update embedded preview ref.', error);
-    });
+    preview.updateFromRef(event.data.token, event.data.reload)
+      .then(markDirectPreviewRefUpdated)
+      .catch(error => {
+        console.error('Failed to update embedded preview ref.', error);
+      });
   });
 }
 

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -96,11 +96,14 @@ if (shouldRunToolbar) {
       const preview = new Preview({
         closePreviewSession: async () => {},
       }, previewCookieHelper, {});
-      setupEmbeddedPreviewPush({ preview });
+      setupEmbeddedPreviewPush({ preview, repository: domain });
       return;
     }
 
     if (isEmbeddedPollPreview) setupEmbeddedPreviewPoll();
+    // Observe before the remote toolbar bootstrap so edits during startup are
+    // not mistaken for the ref already rendered by this page.
+    if (isRegularToolbar) setupDirectPreviewRefWatcher({ repository: domain });
 
     const protocol = domain.match('.test$') ? window.location.protocol : 'https:';
     const toolbarClient = await ToolbarService.getClient(`${protocol}//${domain}/prismic-toolbar/${version}/iframe.html`);
@@ -119,7 +122,6 @@ if (shouldRunToolbar) {
     }
 
     if (isActive) preview.watchPreviewUpdates();
-    else if (isRegularToolbar) setupDirectPreviewRefWatcher();
 
     if (isRegularToolbar && (isActive || previewState.auth)) {
       const prediction = previewState.auth

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -1,7 +1,7 @@
 import './checkBrowser';
 import { ToolbarService } from '@toolbar-service';
 import { toolbarEvents, dispatchToolbarEvent, script } from '@common';
-import { reloadOrigin, getAbsoluteURL } from './utils';
+import { reloadOrigin, getAbsoluteURL, isCompositePreviewRef } from './utils';
 import { Preview } from './preview';
 import { Prediction } from './prediction';
 import { Analytics } from './analytics';
@@ -112,10 +112,18 @@ if (shouldRunToolbar) {
     const { initialRef, isActive } = await preview.setup();
 
     // Skip cookie sync when inactive so we don't clear a preview owned by another tab.
-    if (isActive && previewCookieHelper.sync(initialRef)) {
+    // Composite m-*:p-* refs must not location.reload() — that remounts a spent
+    // /api/preview Wroom URL. Cookie is already upserted by sync().
+    if (
+      isActive
+      && previewCookieHelper.sync(initialRef)
+      && !isCompositePreviewRef(initialRef)
+    ) {
       reloadOrigin();
       return;
     }
+
+    if (isActive) preview.watchPreviewUpdates();
 
     if (isRegularToolbar && (isActive || previewState.auth)) {
       const prediction = previewState.auth

--- a/src/toolbar/index.js
+++ b/src/toolbar/index.js
@@ -1,11 +1,12 @@
 import './checkBrowser';
 import { ToolbarService } from '@toolbar-service';
 import { toolbarEvents, dispatchToolbarEvent, script } from '@common';
-import { reloadOrigin, getAbsoluteURL, isCompositePreviewRef } from './utils';
+import { reloadOrigin, getAbsoluteURL } from './utils';
 import { Preview } from './preview';
 import { Prediction } from './prediction';
 import { Analytics } from './analytics';
 import { PreviewCookie } from './preview/cookie';
+import { setupDirectPreviewRefWatcher } from './direct-preview-watch';
 import {
   EmbeddedPreviewCookie,
   getEmbeddedPreviewMode,
@@ -112,18 +113,13 @@ if (shouldRunToolbar) {
     const { initialRef, isActive } = await preview.setup();
 
     // Skip cookie sync when inactive so we don't clear a preview owned by another tab.
-    // Composite m-*:p-* refs must not location.reload() — that remounts a spent
-    // /api/preview Wroom URL. Cookie is already upserted by sync().
-    if (
-      isActive
-      && previewCookieHelper.sync(initialRef)
-      && !isCompositePreviewRef(initialRef)
-    ) {
+    if (isActive && previewCookieHelper.sync(initialRef)) {
       reloadOrigin();
       return;
     }
 
     if (isActive) preview.watchPreviewUpdates();
+    else if (isRegularToolbar) setupDirectPreviewRefWatcher();
 
     if (isRegularToolbar && (isActive || previewState.auth)) {
       const prediction = previewState.auth

--- a/src/toolbar/preview/cookie.js
+++ b/src/toolbar/preview/cookie.js
@@ -1,5 +1,6 @@
 import { getCookie, setCookie, demolishCookie, isObject } from '@common';
 import { random } from '../../common/general';
+import { clearDirectPreviewRef, getDirectPreviewState } from '../direct-preview-watch';
 
 const PREVIEW_COOKIE_NAME = 'io.prismic.preview';
 
@@ -12,6 +13,7 @@ export class PreviewCookie {
 
   // Align the site cookie with `ref`. Returns true when the page should reload.
   sync(ref) {
+    if (this.isControlledByEditor()) return false;
     if (this.convertLegacyCookieIfNeeded()) return true;
 
     const upToDate = ref === this.getRefForDomain();
@@ -33,6 +35,13 @@ export class PreviewCookie {
   }
 
   get() /* Object | string */ {
+    const directPreview = getDirectPreviewState();
+    if (directPreview) {
+      // Present the regular cookie API without converting the shared raw cookie
+      // or downgrading its cross-site attributes from an authenticated site tab.
+      return { [directPreview.repository]: { preview: directPreview.ref } };
+    }
+
     const cookieOpt = getCookie(PREVIEW_COOKIE_NAME);
     if (cookieOpt) {
       const parsedCookie = (() => {
@@ -49,6 +58,7 @@ export class PreviewCookie {
   }
 
   set(value) {
+    if (this.isControlledByEditor()) return;
     if (value) setCookie(PREVIEW_COOKIE_NAME, value);
     else demolishCookie(PREVIEW_COOKIE_NAME);
   }
@@ -100,6 +110,11 @@ export class PreviewCookie {
   }
 
   deletePreviewForDomain() {
+    const directPreview = getDirectPreviewState();
+    if (directPreview) {
+      if (directPreview.repository !== this.domain) return;
+      clearDirectPreviewRef();
+    }
     const updatedCookieValue = this.build();
     this.set(updatedCookieValue);
   }
@@ -114,6 +129,10 @@ export class PreviewCookie {
     const cookie = this.get();
     if (!cookie) return;
     return cookie._tracker;
+  }
+
+  isControlledByEditor() {
+    return Boolean(getDirectPreviewState());
   }
 
   refreshTracker() {

--- a/src/toolbar/preview/index.js
+++ b/src/toolbar/preview/index.js
@@ -29,7 +29,7 @@ export class Preview {
   };
 
   watchPreviewUpdates() {
-    if (this.active) {
+    if (this.active && !this.interval) {
       this.interval = setInterval(() => {
         // End only on a falsy ping ref (via start → end), not a missing site cookie.
         if (document.visibilityState === 'visible') this.updatePreview();
@@ -39,12 +39,20 @@ export class Preview {
 
   cancelPreviewUpdates() {
     if (this.interval) clearInterval(this.interval);
+    this.interval = null;
   }
 
   async updatePreview() {
+    if (this.isControlledByEditor()) return;
     const { reload, ref } = await this.client.updatePreview();
-    this.start(ref);
-    if (reload) this.reloadPreview(ref);
+    // A push can take ownership while a legacy ping is still in flight.
+    if (this.isControlledByEditor()) return;
+    await this.start(ref);
+    if (ref && reload && !this.isControlledByEditor()) this.reloadPreview(ref);
+  }
+
+  isControlledByEditor() {
+    return this.cookie.isControlledByEditor && this.cookie.isControlledByEditor();
   }
 
   async updateFromRef(ref, reload) {
@@ -82,8 +90,16 @@ export class Preview {
 
   // End preview
   async end() {
+    const controlledAtStart = this.isControlledByEditor();
     this.cancelPreviewUpdates();
     await this.client.closePreviewSession();
+    // Closing the remote legacy session yields too. Do not clear a newer
+    // editor ref that arrived while that close request was pending.
+    if (!controlledAtStart && this.isControlledByEditor()) {
+      this.watchPreviewUpdates();
+      return;
+    }
+    this.active = false;
     this.cookie.deletePreviewForDomain();
 
     // Dispatch the end event and hard reload if not cancelled by handlers

--- a/src/toolbar/preview/index.js
+++ b/src/toolbar/preview/index.js
@@ -1,5 +1,5 @@
 import { toolbarEvents, dispatchToolbarEvent, getLocation } from '@common';
-import { reloadOrigin } from '../utils';
+import { isCompositePreviewRef, reloadOrigin } from '../utils';
 import screenshot from './screenshot';
 
 export class Preview {
@@ -20,10 +20,6 @@ export class Preview {
     this.title = preview.title;
     this.updated = preview.updated;
     this.documents = preview.documents || [];
-
-    const refUpToDate = preview.ref === this.cookie.getRefForDomain();
-    // Start polling only when the cookie already matches; otherwise sync + reload will.
-    if (this.active && refUpToDate) this.watchPreviewUpdates();
 
     return {
       isActive: this.active,
@@ -50,15 +46,18 @@ export class Preview {
     if (reload) this.reloadPreview(ref);
   }
 
-  async updateFromRef(ref) {
+  async updateFromRef(ref, reload) {
     const { shouldReload } = await this.start(ref);
+    const skipHardReload = reload === false || isCompositePreviewRef(ref);
 
-    if (shouldReload) this.reloadPreview(ref);
+    // reload: false or m-*:p-* : cookie already upserted; notify, never remount.
+    // Missing/undefined reload keeps the legacy mismatch → location.reload() path.
+    if (shouldReload || skipHardReload) this.reloadPreview(ref, reload);
   }
 
-  reloadPreview(ref) {
-    // Dispatch the update event and hard reload if not cancelled by handlers
+  reloadPreview(ref, reload) {
     if (dispatchToolbarEvent(toolbarEvents.previewUpdate, { ref })) {
+      if (reload === false || isCompositePreviewRef(ref)) return;
       this.cancelPreviewUpdates();
       reloadOrigin();
     }

--- a/src/toolbar/preview/index.js
+++ b/src/toolbar/preview/index.js
@@ -1,5 +1,5 @@
 import { toolbarEvents, dispatchToolbarEvent, getLocation } from '@common';
-import { isCompositePreviewRef, reloadOrigin } from '../utils';
+import { reloadOrigin } from '../utils';
 import screenshot from './screenshot';
 
 export class Preview {
@@ -7,6 +7,7 @@ export class Preview {
     this.cookie = previewCookie;
     this.client = client;
     this.state = previewState;
+    this.lastRefFromPush = null;
 
     this.end = this.end.bind(this);
     this.share = this.share.bind(this);
@@ -47,17 +48,19 @@ export class Preview {
   }
 
   async updateFromRef(ref, reload) {
-    const { shouldReload } = await this.start(ref);
-    const skipHardReload = reload === false || isCompositePreviewRef(ref);
+    if (ref === this.lastRefFromPush && ref === this.cookie.getRefForDomain()) return;
 
-    // reload: false or m-*:p-* : cookie already upserted; notify, never remount.
+    const { shouldReload } = await this.start(ref);
+    this.lastRefFromPush = ref;
+
+    // reload: false: cookie already upserted; notify, never remount.
     // Missing/undefined reload keeps the legacy mismatch → location.reload() path.
-    if (shouldReload || skipHardReload) this.reloadPreview(ref, reload);
+    if (reload === false || shouldReload) this.reloadPreview(ref, reload);
   }
 
   reloadPreview(ref, reload) {
     if (dispatchToolbarEvent(toolbarEvents.previewUpdate, { ref })) {
-      if (reload === false || isCompositePreviewRef(ref)) return;
+      if (reload === false) return;
       this.cancelPreviewUpdates();
       reloadOrigin();
     }

--- a/src/toolbar/utils.js
+++ b/src/toolbar/utils.js
@@ -1,5 +1,9 @@
 export const reloadOrigin = () => window.location.reload();
 
+// Publication live preview refs: master overlay + draft (`m-…:p-…`).
+export const isCompositePreviewRef = ref =>
+  typeof ref === 'string' && /^m-[^:]+:p-.+$/.test(ref);
+
 let a;
 export const getAbsoluteURL = url => {
   if (!a) a = document.createElement('a');

--- a/src/toolbar/utils.js
+++ b/src/toolbar/utils.js
@@ -1,9 +1,5 @@
 export const reloadOrigin = () => window.location.reload();
 
-// Publication live preview refs: master overlay + draft (`m-…:p-…`).
-export const isCompositePreviewRef = ref =>
-  typeof ref === 'string' && /^m-[^:]+:p-.+$/.test(ref);
-
 let a;
 export const getAbsoluteURL = url => {
   if (!a) a = document.createElement('a');

--- a/tests/preview.test.cjs
+++ b/tests/preview.test.cjs
@@ -1,0 +1,470 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { transformSync } = require('@babel/core');
+
+const root = path.resolve(__dirname, '..');
+const tests = [];
+const test = (name, run) => tests.push({ name, run });
+const repository = 'example.platform-wroom.com';
+const cookieName = 'io.prismic.preview';
+const markerName = 'io.prismic.preview.updated';
+const marker = (ref, repo = repository) => JSON.stringify({ version: 2, repository: repo, ref });
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+function harness({ cookies: initialCookies = {}, framed = false, hostname = 'localhost', protocol = 'http:', cancelEvents = true, previewState = {}, serviceReady, reloadStorage = new Map() } = {}) {
+  const cookies = { ...initialCookies };
+  const writes = [];
+  const events = [];
+  const intervals = [];
+  const listeners = {};
+  const messages = [];
+  const window = {
+    name: framed ? 'prismic:embedded-preview' : '',
+    location: { hostname, protocol, pathname: '/page', href: protocol + '//' + hostname + '/page', reload: () => { result.reloads += 1; } },
+    sessionStorage: {
+      getItem: key => reloadStorage.get(key) ?? null,
+      setItem: (key, value) => reloadStorage.set(key, value),
+      removeItem: key => reloadStorage.delete(key),
+    },
+    parent: { postMessage: (...args) => messages.push(args) },
+    setInterval: (run, ms) => { const interval = { run, ms }; intervals.push(interval); return interval; },
+    clearInterval: interval => { interval.cleared = true; },
+    addEventListener: (name, listener) => { listeners[name] = listener; },
+    dispatchEvent: event => { events.push(event); if (result.onEvent) result.onEvent(event); return !cancelEvents; },
+  };
+  window.self = window;
+  window.top = framed ? {} : window;
+  const document = {
+    visibilityState: 'visible',
+    currentScript: { getAttribute: () => 'http://localhost/prismic.js?repo=' + repository },
+    createElement: () => ({ href: '' }),
+  };
+  const result = { cookies, writes, events, intervals, listeners, messages, window, reloads: 0, pingCount: 0, closeCount: 0 };
+  const client = {
+    hostname: repository,
+    getPreviewState: async () => previewState,
+    closePreviewSession: async () => { result.closeCount += 1; },
+    updatePreview: async () => { result.pingCount += 1; return { ref: 'legacy-next', reload: true }; },
+  };
+  result.client = client;
+  const cache = new Map();
+  const context = vm.createContext({
+    window, document, URL, console, setInterval: window.setInterval, clearInterval: window.clearInterval,
+    CDN_HOST: 'https://prismic.io',
+    process: { env: { npm_package_version: '4.1.6' } },
+    CustomEvent: class { constructor(type, options) { this.type = type; Object.assign(this, options); } },
+  });
+  const cookieLibrary = {
+    get: name => cookies[name],
+    set: (name, value, attributes) => {
+      writes.push({ name, value, attributes });
+      cookies[name] = typeof value === 'object' ? JSON.stringify(value) : value;
+    },
+    remove: (name, attributes) => { writes.push({ name, attributes, removed: true }); delete cookies[name]; },
+  };
+  const mocks = {
+    'js-cookie': cookieLibrary,
+    '@toolbar-service': { ToolbarService: { getClient: async () => { if (serviceReady) await serviceReady; return client; } } },
+    [path.join(root, 'src/toolbar/checkBrowser.js')]: {},
+    [path.join(root, 'src/toolbar/preview/screenshot.js')]: () => {},
+    [path.join(root, 'src/toolbar/embedded-preview/document-height.js')]: { startDocumentHeightReporting: () => { result.heightStarted = true; } },
+    [path.join(root, 'src/toolbar/analytics.js')]: { Analytics: class {} },
+  };
+  function load(file, parent = path.join(root, 'src/index.js')) {
+    if (mocks[file]) return mocks[file];
+    let filename = file.startsWith('.') ? path.resolve(path.dirname(parent), file) : file;
+    if (file === '@common') {
+      return {
+        ...load(path.join(root, 'src/common/cookie.js')),
+        ...load(path.join(root, 'src/common/events.js')),
+        once: fn => { let called; return (...args) => { if (!called) { called = true; return fn(...args); } }; },
+        isObject: value => value !== null && typeof value === 'object',
+        script: async () => {},
+      };
+    }
+    if (!path.extname(filename)) filename = fs.existsSync(filename + '.js') ? filename + '.js' : path.join(filename, 'index.js');
+    if (mocks[filename]) return mocks[filename];
+    if (filename.endsWith('/common/general.js')) return { random: () => 'tracker' };
+    if (cache.has(filename)) return cache.get(filename).exports;
+    const module = { exports: {} };
+    cache.set(filename, module);
+    const source = transformSync(fs.readFileSync(filename, 'utf8'), {
+      filename, babelrc: false, configFile: false,
+      presets: [['@babel/preset-env', { targets: { node: 'current' } }]],
+      plugins: ['@babel/plugin-proposal-class-properties'],
+    }).code;
+    const run = vm.runInContext('(function(require, module, exports) {' + source + '\n})', context, { filename });
+    run(request => load(request, filename), module, module.exports);
+    return module.exports;
+  }
+  result.load = file => load(path.join(root, file));
+  result.direct = result.load('src/toolbar/direct-preview-watch.js');
+  result.watch = () => result.direct.createDirectPreviewRefWatcher({ repository });
+  result.previewCookie = () => new (result.load('src/toolbar/preview/cookie.js').PreviewCookie)(true, repository);
+  result.preview = cookie => new (result.load('src/toolbar/preview/index.js').Preview)(client, cookie, previewState);
+  return result;
+}
+
+test('standalone falls back to reloading when no listener handles an update', () => {
+  const h = harness({ cancelEvents: false });
+  const watch = h.watch();
+  h.cookies[cookieName] = 'new-ref';
+  h.cookies[markerName] = marker('new-ref');
+  watch();
+  assert.strictEqual(h.reloads, 1);
+});
+
+test('startup reconciles an owned cookie that may be newer than server-rendered content', () => {
+  const h = harness({ cookies: { [cookieName]: 'newer-than-SSR', [markerName]: marker('newer-than-SSR') } });
+  const watch = h.watch();
+  watch();
+  watch();
+  assert.deepStrictEqual(h.events.map(event => event.detail.ref), ['newer-than-SSR']);
+  assert.strictEqual(h.reloads, 0);
+});
+
+test('generic startup reloads once per ref and URL without looping across page loads', () => {
+  const reloadStorage = new Map();
+  const options = { cancelEvents: false, reloadStorage, cookies: { [cookieName]: 'owned', [markerName]: marker('owned') } };
+  const firstPage = harness(options);
+  firstPage.watch()();
+  assert.strictEqual(firstPage.reloads, 1);
+  const reloadedPage = harness(options);
+  reloadedPage.watch()();
+  assert.strictEqual(reloadedPage.reloads, 0);
+  const otherPage = harness(options);
+  otherPage.window.location.href = 'http://localhost/another-page';
+  otherPage.watch()();
+  assert.strictEqual(otherPage.reloads, 1);
+});
+
+test('blocked session storage cannot create a startup reload loop', () => {
+  const h = harness({ cancelEvents: false, cookies: { [cookieName]: 'owned', [markerName]: marker('owned') } });
+  h.window.sessionStorage.getItem = () => { throw new Error('Storage unavailable'); };
+  const watch = h.watch();
+  watch();
+  assert.strictEqual(h.events.length, 1);
+  assert.strictEqual(h.reloads, 0);
+  h.cookies[cookieName] = 'later';
+  h.cookies[markerName] = marker('later');
+  watch();
+  assert.strictEqual(h.reloads, 1);
+});
+
+test('startup keeps a ref change received before the first tick and avoids a second reload', () => {
+  const reloadStorage = new Map();
+  const h = harness({ cancelEvents: false, reloadStorage, cookies: { [cookieName]: 'A', [markerName]: marker('A') } });
+  const watch = h.watch();
+  h.cookies[cookieName] = 'B';
+  h.cookies[markerName] = marker('B');
+  watch();
+  assert.deepStrictEqual(h.events.map(event => event.detail.ref), ['B']);
+  assert.strictEqual(h.reloads, 1);
+  const nextPage = harness({ cancelEvents: false, reloadStorage, cookies: { ...h.cookies } });
+  nextPage.watch()();
+  assert.strictEqual(nextPage.reloads, 0);
+});
+
+test('preview exit permits startup reconciliation when the same ref is opened again', () => {
+  const reloadStorage = new Map();
+  const options = { cancelEvents: false, reloadStorage, cookies: { [cookieName]: 'A', [markerName]: marker('A') } };
+  const h = harness(options);
+  const watch = h.watch();
+  watch();
+  delete h.cookies[cookieName];
+  delete h.cookies[markerName];
+  watch();
+  const reopenedPage = harness(options);
+  reopenedPage.watch()();
+  assert.strictEqual(reopenedPage.reloads, 1);
+});
+
+test('a canceled standalone update remains soft and duplicate refs do nothing', () => {
+  const h = harness({ cookies: { [cookieName]: 'old-ref', [markerName]: marker('old-ref') } });
+  const watch = h.watch();
+  h.cookies[cookieName] = '{"looks":"like JSON"}';
+  h.cookies[markerName] = marker(h.cookies[cookieName]);
+  watch();
+  watch();
+  assert.strictEqual(h.events.length, 1);
+  assert.strictEqual(h.events[0].detail.ref, '{"looks":"like JSON"}');
+  assert.strictEqual(h.reloads, 0);
+});
+
+test('stale, old-version and foreign-repository markers never claim a legacy ref', () => {
+  for (const value of ['v1', marker('stale'), marker('current', 'another.prismic.io'), '{', 'null']) {
+    const h = harness({ cookies: { [cookieName]: 'current', [markerName]: value } });
+    const watch = h.watch();
+    h.cookies[cookieName] = 'legacy-change';
+    watch();
+    assert.strictEqual(h.events.length, 0, value);
+  }
+});
+
+test('standalone detects preview exit once and can restart at the same ref', () => {
+  const h = harness({ cookies: { [cookieName]: 'A', [markerName]: marker('A') } });
+  const watch = h.watch();
+  delete h.cookies[cookieName];
+  delete h.cookies[markerName];
+  watch();
+  watch();
+  h.cookies[cookieName] = 'A';
+  h.cookies[markerName] = marker('A');
+  watch();
+  assert.deepStrictEqual(h.events.map(event => event.type), ['prismicPreviewEnd', 'prismicPreviewUpdate']);
+});
+
+test('authenticated prediction reads and tracker refresh do not rewrite an editor ref', () => {
+  const h = harness({ cookies: { [cookieName]: 'opaque', [markerName]: marker('opaque') } });
+  const cookie = h.previewCookie();
+  assert.strictEqual(cookie.getTracker(), undefined);
+  cookie.refreshTracker();
+  assert.strictEqual(cookie.getRefForDomain(), 'opaque');
+  assert.strictEqual(h.cookies[cookieName], 'opaque');
+  assert.strictEqual(h.writes.length, 0);
+});
+
+test('editor ownership prevents legacy startup sync and polling from overwriting the cookie', async () => {
+  const h = harness({ cookies: { [cookieName]: 'editor', [markerName]: marker('editor') } });
+  const cookie = h.previewCookie();
+  assert.strictEqual(cookie.sync('legacy'), false);
+  const preview = h.preview(cookie);
+  await preview.updatePreview();
+  assert.strictEqual(h.pingCount, 0);
+  assert.strictEqual(h.cookies[cookieName], 'editor');
+});
+
+test('a legacy ping already in flight is discarded after editor takeover', async () => {
+  const h = harness();
+  let finishPing;
+  h.client.updatePreview = () => new Promise(resolve => { finishPing = resolve; });
+  const preview = h.preview(h.previewCookie());
+  const pending = preview.updatePreview();
+  h.cookies[cookieName] = 'editor';
+  h.cookies[markerName] = marker('editor');
+  finishPing({ ref: 'legacy', reload: true });
+  await pending;
+  assert.strictEqual(h.cookies[cookieName], 'editor');
+  assert.strictEqual(h.events.length, 0);
+  assert.strictEqual(h.reloads, 0);
+});
+
+test('editor takeover also wins while legacy session cleanup is in flight', async () => {
+  const h = harness();
+  let finishClose;
+  h.client.updatePreview = async () => ({ ref: null, reload: true });
+  h.client.closePreviewSession = () => new Promise(resolve => { finishClose = resolve; });
+  const pending = h.preview(h.previewCookie()).updatePreview();
+  await flush();
+  h.cookies[cookieName] = 'editor';
+  h.cookies[markerName] = marker('editor');
+  finishClose();
+  await pending;
+  assert.strictEqual(h.cookies[cookieName], 'editor');
+  assert.strictEqual(h.events.length, 0);
+});
+
+test('a falsy legacy ping ends once without dispatching a stale update as well', async () => {
+  const h = harness({ cancelEvents: false });
+  h.client.updatePreview = async () => ({ ref: null, reload: true });
+  await h.preview(h.previewCookie()).updatePreview();
+  assert.deepStrictEqual(h.events.map(event => event.type), ['prismicPreviewEnd']);
+  assert.strictEqual(h.reloads, 1);
+});
+
+test('a new legacy cookie invalidates editor ownership and preserves legacy polling', async () => {
+  const h = harness({ cookies: { [cookieName]: 'legacy', [markerName]: marker('old-editor') } });
+  const preview = h.preview(h.previewCookie());
+  await preview.updatePreview();
+  assert.strictEqual(h.pingCount, 1);
+  assert.strictEqual(h.previewCookie().getRefForDomain(), 'legacy-next');
+  assert.strictEqual(h.events.length, 1);
+});
+
+test('ending an editor-owned preview clears the cookie and its marker', () => {
+  const h = harness({ cookies: { [cookieName]: 'editor', [markerName]: marker('editor') } });
+  h.previewCookie().deletePreviewForDomain();
+  assert.strictEqual(h.cookies[cookieName], undefined);
+  assert.strictEqual(h.cookies[markerName], undefined);
+});
+
+test('another repository cannot rewrite or delete an editor-owned cookie', () => {
+  const h = harness({ cookies: { [cookieName]: 'other', [markerName]: marker('other', 'another.prismic.io') } });
+  const cookie = h.previewCookie();
+  assert.strictEqual(cookie.getRefForDomain(), undefined);
+  cookie.refreshTracker();
+  cookie.upsertPreviewForDomain('local');
+  cookie.deletePreviewForDomain();
+  assert.strictEqual(h.cookies[cookieName], 'other');
+  assert.strictEqual(h.writes.length, 0);
+});
+
+test('push reload:false writes an opaque ref, emits once and never hard reloads', async () => {
+  const h = harness({ framed: true, cancelEvents: false });
+  const { EmbeddedPreviewCookie } = h.load('src/toolbar/embedded-preview/index.js');
+  const preview = h.preview(new EmbeddedPreviewCookie());
+  await preview.updateFromRef('not:a:parsed-format', false);
+  await preview.updateFromRef('not:a:parsed-format', false);
+  assert.strictEqual(h.cookies[cookieName], 'not:a:parsed-format');
+  assert.strictEqual(h.events.length, 1);
+  assert.strictEqual(h.reloads, 0);
+});
+
+test('old editor pushes retain the hard reload fallback on mismatch', async () => {
+  const h = harness({ framed: true, cancelEvents: false });
+  const { EmbeddedPreviewCookie } = h.load('src/toolbar/embedded-preview/index.js');
+  await h.preview(new EmbeddedPreviewCookie()).updateFromRef('legacy');
+  assert.strictEqual(h.reloads, 1);
+});
+
+test('an unchanged old-editor ref is already synchronized without a reload', async () => {
+  const h = harness({ framed: true, cancelEvents: false, cookies: { [cookieName]: 'legacy' } });
+  const { EmbeddedPreviewCookie } = h.load('src/toolbar/embedded-preview/index.js');
+  await h.preview(new EmbeddedPreviewCookie()).updateFromRef('legacy');
+  assert.strictEqual(h.reloads, 0);
+  assert.strictEqual(h.events.length, 0);
+});
+
+test('a matched cookie still gets its initial controlled refresh', async () => {
+  const h = harness({ framed: true, cancelEvents: false, cookies: { [cookieName]: 'opaque' } });
+  const { EmbeddedPreviewCookie } = h.load('src/toolbar/embedded-preview/index.js');
+  await h.preview(new EmbeddedPreviewCookie()).updateFromRef('opaque', false);
+  assert.strictEqual(h.reloads, 0);
+  assert.strictEqual(h.events.length, 1);
+});
+
+test('malformed parent messages cannot update the cookie', async () => {
+  const h = harness({ framed: true });
+  const { EmbeddedPreviewCookie, setupEmbeddedPreviewPush } = h.load('src/toolbar/embedded-preview/index.js');
+  setupEmbeddedPreviewPush({ preview: h.preview(new EmbeddedPreviewCookie()), repository });
+  for (const data of [null, {}, { type: 'wrong', token: 'A' }, { type: 'prismic:embedded-preview:set-ref', token: '' }, { type: 'prismic:embedded-preview:set-ref', token: {} }]) {
+    h.listeners.message({ origin: 'https://example.platform-wroom.com', source: h.window.parent, data });
+  }
+  await flush();
+  assert.strictEqual(h.writes.length, 0);
+});
+
+test('pending ownership takes effect only when its ref matches the actual cookie', () => {
+  const h = harness({ cookies: { [cookieName]: 'older' } });
+  h.direct.markDirectPreviewRefUpdated({ repository, ref: 'newer' });
+  assert.strictEqual(h.direct.getDirectPreviewState(), undefined);
+  h.cookies[cookieName] = 'newer';
+  assert.strictEqual(h.direct.getDirectPreviewState().ref, 'newer');
+});
+
+test('only trusted parent reload:false messages establish explicit ownership', async () => {
+  const h = harness({ framed: true });
+  const { EmbeddedPreviewCookie, setupEmbeddedPreviewPush } = h.load('src/toolbar/embedded-preview/index.js');
+  const preview = h.preview(new EmbeddedPreviewCookie());
+  setupEmbeddedPreviewPush({ preview, repository });
+  const data = { type: 'prismic:embedded-preview:set-ref', token: 'opaque', reload: false };
+  h.listeners.message({ origin: 'https://evil.example', source: h.window.parent, data });
+  h.listeners.message({ origin: 'https://example.platform-wroom.com', source: {}, data });
+  h.listeners.message({ origin: 'https://example.platform-wroom.com.attacker.example', source: h.window.parent, data });
+  await flush();
+  assert.strictEqual(h.cookies[cookieName], undefined);
+  h.listeners.message({ origin: 'https://example.platform-wroom.com', source: h.window.parent, data });
+  await flush();
+  assert.strictEqual(h.cookies[markerName], marker('opaque'));
+  const markerWrite = h.writes.find(write => write.name === markerName);
+  assert.strictEqual(markerWrite.attributes.expires, null);
+  assert.strictEqual(markerWrite.attributes.sameSite, 'none');
+  assert.strictEqual(markerWrite.attributes.secure, true);
+  delete h.cookies[markerName];
+  h.listeners.message({ origin: 'https://example.platform-wroom.com', source: h.window.parent, data: { ...data, token: 'old-editor', reload: true } });
+  await flush();
+  assert.strictEqual(h.cookies[markerName], undefined);
+});
+
+test('ownership is established before an update listener can convert the shared cookie', async () => {
+  const h = harness({ framed: true });
+  const { EmbeddedPreviewCookie, setupEmbeddedPreviewPush } = h.load('src/toolbar/embedded-preview/index.js');
+  setupEmbeddedPreviewPush({ preview: h.preview(new EmbeddedPreviewCookie()), repository });
+  h.onEvent = event => {
+    if (event.type === 'prismicPreviewUpdate') {
+      const regularCookie = h.previewCookie();
+      regularCookie.getTracker();
+      regularCookie.refreshTracker();
+    }
+  };
+  h.listeners.message({
+    origin: 'https://example.platform-wroom.com', source: h.window.parent,
+    data: { type: 'prismic:embedded-preview:set-ref', token: 'new-ref', reload: false },
+  });
+  await flush();
+  assert.strictEqual(h.cookies[cookieName], 'new-ref');
+  assert.strictEqual(h.cookies[markerName], marker('new-ref'));
+});
+
+test('loopback iframe cookie writes retain SameSite=None; Secure without changing normal HTTP hosts', () => {
+  for (const hostname of ['localhost', '127.0.0.1', '[::1]']) {
+    const h = harness({ framed: true, hostname });
+    h.load('src/common/cookie.js').setCookie('example', 'value');
+    assert.strictEqual(h.writes[0].attributes.sameSite, 'none');
+    assert.strictEqual(h.writes[0].attributes.secure, true);
+  }
+  const h = harness({ framed: true, hostname: 'site.test' });
+  h.load('src/common/cookie.js').setCookie('example', 'value');
+  assert.strictEqual(h.writes[0].attributes.sameSite, 'lax');
+  assert.strictEqual(h.writes[0].attributes.secure, undefined);
+});
+
+test('standalone watcher starts before remote toolbar bootstrap can swallow an edit', async () => {
+  let resolveService;
+  const h = harness({ serviceReady: new Promise(resolve => { resolveService = resolve; }) });
+  h.load('src/toolbar/index.js');
+  assert.strictEqual(h.intervals.length, 1);
+  assert.strictEqual(h.intervals[0].ms, 250);
+  h.cookies[cookieName] = 'during-startup';
+  h.cookies[markerName] = marker('during-startup');
+  h.intervals[0].run();
+  assert.strictEqual(h.events.filter(event => event.type === 'prismicPreviewUpdate').length, 1);
+  resolveService();
+  await flush();
+});
+
+test('legacy standalone keeps its three-second poll alongside the direct watcher', async () => {
+  const h = harness({
+    previewState: { preview: { ref: 'legacy' } },
+    cookies: { [cookieName]: JSON.stringify({ [repository]: { preview: 'legacy' } }) },
+  });
+  h.window.prismic = { Toolbar: class {} };
+  h.load('src/toolbar/index.js');
+  await flush();
+  assert.deepStrictEqual(h.intervals.map(interval => interval.ms).sort(), [250, 3000]);
+});
+
+test('controlled iframe never starts either cookie watching or legacy polling', async () => {
+  const h = harness({ framed: true });
+  h.load('src/toolbar/index.js');
+  await flush();
+  assert.strictEqual(h.intervals.length, 0);
+  assert.strictEqual(h.messages[0][0].type, 'prismic:embedded-preview:ready');
+});
+
+test('unrelated iframes do not initialize the toolbar', async () => {
+  const h = harness({ framed: true });
+  h.window.name = 'unrelated-iframe';
+  h.load('src/toolbar/index.js');
+  await flush();
+  assert.strictEqual(h.intervals.length, 0);
+  assert.strictEqual(h.messages.length, 0);
+  assert.strictEqual(h.window.prismic, undefined);
+});
+
+(async () => {
+  let failed = 0;
+  for (const { name, run } of tests) {
+    try {
+      await run();
+      console.log('PASS ' + name);
+    } catch (error) {
+      failed += 1;
+      console.error('FAIL ' + name + '\n' + error.stack);
+    }
+  }
+  console.log(`${tests.length - failed}/${tests.length} preview tests passed`);
+  process.exitCode = failed ? 1 : 0;
+})();


### PR DESCRIPTION
**TL;DR** — Keep editor previews updating in place while preserving live updates in standalone site tabs.

An editor-pushed ref must not trigger a hard reload of the preview iframe. This change honors `reload: false` and prevents a standalone tab's legacy polling or authenticated tracking from overwriting that ref or its cross-site cookie attributes.

## Product & functional impact

- Editor-controlled pushes update the cookie and emit the cancelable preview event without hard reloading; repeated refs are ignored after initial synchronization.
- Standalone tabs observe the local preview cookie every 250 ms, reconcile changes that arrived before toolbar startup, and receive preview-exit events.
- Legacy previews keep their 3-second server poll and existing hard-reload fallback; older editor messages without `reload: false` retain their behavior.

## Ownership and compatibility

- A session cookie records explicit protocol metadata `{ version: 2, repository, ref }` before the pushed ref is written; ownership applies only while the actual cookie matches. Ref values remain opaque: no composite-format detection or parsing.
- While the editor owns the cookie, regular toolbar reads preserve its raw value, tracker writes and legacy synchronization leave it intact, and pending legacy responses cannot replace or delete it. A new legacy ref or explicit legacy push releases ownership.
- Embedded HTTPS and HTTP loopback writes use `SameSite=None; Secure`; ordinary HTTP hosts retain the existing policy.
- The old `v1` marker is ignored, not migrated. Refresh existing test tabs onto this bundle and reopen the editor preview so a new `reload: false` push establishes v2 ownership; mixed old/new toolbar tabs do not provide the new protection.

**Standalone fallback** — Sites without a soft-update listener still reload; session storage remembers this tab's last reloaded URL/ref to prevent startup reload loops and resets on exit. If storage is unavailable, startup emits the event without hard reloading; later ref changes retain the reload fallback.

**Companion changes** — Pair with [editor#2487](https://github.com/prismicio/editor/pull/2487) for controlled pushes and [prismic-next#147](https://github.com/prismicio/prismic-next/pull/147) for Next.js preview cookies and refresh handling.

## Verification

- 30 behavioral regressions pass, including opaque refs, message-origin/source checks, ownership takeover, pending legacy cleanup, startup reconciliation, exit/reopen, generic fallback, and legacy polling.
- Lint, production build, and diff checks pass.
- Independent browser reproduction passes: server-rendered A, cookie B before the toolbar loads, then C all converge through one event per observed ref while preserving the page document.
- Final Platform editor `dd1073824` + this toolbar `6c6ab38` + Next alpha `2.3.1-pr.147.286b2d0` passed the HTTP localhost `next dev` smoke: Form and Properties changes reached both iframes and the standalone tab in approximately 1.6 s / 1.45 s without new page documents. Cold standalone activation, exit/reopen, and UID navigation were also exercised with the paired changes. This bundle still requires a local build until CDN publication.
